### PR TITLE
Center hero section content

### DIFF
--- a/content/webentwicklung/index.css
+++ b/content/webentwicklung/index.css
@@ -540,7 +540,7 @@ a:hover {
 min-height: 100vh;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   padding: 12px 0;
   position: relative;
   overflow: hidden;
@@ -548,7 +548,7 @@ min-height: 100vh;
 }
 
 .hero.section {
-  justify-content: flex-start; /* oder center, je nach gewünschtem Effekt */
+  justify-content: center; /* Inhalte vertikal zentrieren */
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- center hero section elements in the viewport by using `justify-content: center`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ff9f85ec832e934511c9391a5156