### PR TITLE
Add debounce cancel and throttle tests

### DIFF
--- a/content/webentwicklung/main.js
+++ b/content/webentwicklung/main.js
@@ -1,11 +1,14 @@
 // ===== Debounce & Throttle =====
 function debounce(func, wait) {
   let timeout;
-  return function executedFunction(...args) {
+  function debounced(...args) {
     clearTimeout(timeout);
     timeout = setTimeout(() => func.apply(this, args), wait);
-  };
+  }
+  debounced.cancel = () => clearTimeout(timeout);
+  return debounced;
 }
+
 function throttle(func, limit) {
   let inThrottle;
   return function () {
@@ -19,7 +22,7 @@ function throttle(func, limit) {
 
 // Export for testing
 if (typeof module !== 'undefined') {
-  module.exports = { debounce };
+  module.exports = { debounce, throttle };
 }
 
 // ===== Typed Text Animation =====

--- a/tests/debounce.test.js
+++ b/tests/debounce.test.js
@@ -16,4 +16,15 @@ describe('debounce', () => {
     jest.advanceTimersByTime(1);
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  test('cancel prevents the callback from firing', () => {
+    const callback = jest.fn();
+    const debounced = debounce(callback, 100);
+
+    debounced();
+    debounced.cancel();
+    jest.advanceTimersByTime(100);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
 });

--- a/tests/throttle.test.js
+++ b/tests/throttle.test.js
@@ -1,0 +1,19 @@
+const { throttle } = require('../content/webentwicklung/main.js');
+
+describe('throttle', () => {
+  jest.useFakeTimers();
+
+  test('limits function calls to once per interval', () => {
+    const callback = jest.fn();
+    const throttled = throttle(callback, 100);
+
+    throttled();
+    throttled();
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(100);
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- allow debounced functions to be canceled before execution
- expose throttle utility and add tests for throttling behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68971ad9e670832ebe163619d42c2e1f