### PR TITLE
fix: prevent header from altering page width

### DIFF
--- a/content/webentwicklung/menu/menu.css
+++ b/content/webentwicklung/menu/menu.css
@@ -7,6 +7,10 @@
   box-sizing: border-box;
 }
 
+html, body {
+  overflow-x: hidden;
+}
+
 /* =======================
    Typography
    ======================= */
@@ -35,7 +39,10 @@
   text-decoration: none;
 }
 .site-header {
-  top: 0; left: 0; width: 100vw;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
   min-height: 48px;
   padding: clamp(0.25rem, 1vw, 0.7rem) clamp(0.5rem, 3vw, 2rem);
   position: fixed;


### PR DESCRIPTION
## Summary
- ensure site header respects viewport width and eliminate horizontal scroll
- prevent horizontal overflow on entire page

## Testing
- `npm test` *(fails: debounce and throttle are not functions)*

------
https://chatgpt.com/codex/tasks/task_e_689977d73544832e833e09d8cb76ab70