### PR TITLE
Fix mobile scroll hang and add testable utilities

### DIFF
--- a/content/webentwicklung/index.css
+++ b/content/webentwicklung/index.css
@@ -79,7 +79,7 @@
 html, body {
   height: 100%;
   overflow-x: hidden;
-  touch-action: pen-y;
+  touch-action: pan-y;
   
 }
 

--- a/content/webentwicklung/main.js
+++ b/content/webentwicklung/main.js
@@ -11,7 +11,14 @@
 //  - Overlay (in animations.js) liest Partikel-/Animations-Stats
 // ===== Dynamic Imports + Fallbacks =====
 let debounce = (fn, wait = 200) => {
-  let t; return function(...args){ const ctx=this; clearTimeout(t); t=setTimeout(()=>fn.apply(ctx,args), wait); };
+  let t;
+  function debounced(...args){
+    const ctx=this;
+    clearTimeout(t);
+    t=setTimeout(()=>fn.apply(ctx,args), wait);
+  }
+  debounced.cancel = () => clearTimeout(t);
+  return debounced;
 };
 let throttle = (fn, limit = 250) => {
   let inFlight=false, pending=false, lastArgs, lastThis;
@@ -475,4 +482,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Falls Hero später nachgeladen wird erneut durch hero.js aufrufbar
 
 });
+
+// Für Tests exportieren
+if (typeof module !== 'undefined') {
+  module.exports = { debounce, throttle };
+}
 


### PR DESCRIPTION
## Summary
- Correct typo in touch-action to allow smooth vertical scrolling on mobile
- Enhance debounce utility with cancel support and export debounce/throttle for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899ac19e934832ebb32d5a4f4e1dce3