### PR TITLE
Add global background layer with transparent sections

### DIFF
--- a/content/webentwicklung/features/features-templates.html
+++ b/content/webentwicklung/features/features-templates.html
@@ -1,9 +1,9 @@
 <!-- Feature Templates (alle zusammengeführt) -->
 <style>
     /* -- Features Cards (Snap Section) -- */
-.features { 
+.features {
   display: flex; flex-direction: column; justify-content: center; align-items: center;
-  background: var(--bg-section);
+  background: transparent;
   scroll-snap-align: center;
 }
 .features-cards { 

--- a/content/webentwicklung/footer/footer.html
+++ b/content/webentwicklung/footer/footer.html
@@ -24,7 +24,7 @@
 }
 
     .footer-container .footer {
-      background: var(--bg-section);
+      background: transparent;
       padding: var(--spacing-2xl) 0 var(--spacing-lg);
       margin-top: var(--spacing-2xl);
       color: var(--text-secondary);

--- a/content/webentwicklung/home/hero.html
+++ b/content/webentwicklung/home/hero.html
@@ -38,10 +38,6 @@ body.reduce-motion .anim-soft.animate-element { transform: none !important; opac
 .btn-crt.btn-secondary.animate-element.is-visible:hover { background: var(--primary-color); color:#fff; }
 body.reduce-motion [data-animation="crt"].animate-element { opacity:1 !important; transform:none !important; filter:none !important; animation:none !important; }
 body.reduce-motion [data-animation="crt"].animate-element::before, body.reduce-motion [data-animation="crt"].animate-element::after { display:none !important; }
-/* Background Layer */
-.hero-background { position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: -1; }
-.gradient-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: radial-gradient(ellipse at center, transparent 0%, var(--bg-dark) 100%); }
-.particle-canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0.5; }
 /* Subtitle (typing area) */
 .hero-subtitle{ position: absolute; left: clamp(12px, 2vw, 20px); bottom: calc(clamp(12px, 2vw, 20px) + env(safe-area-inset-bottom)); z-index: 10; margin: 0; display: flex; flex-direction: column; align-items: flex-start; text-align: left; -webkit-font-smoothing: auto; -moz-osx-font-smoothing: auto; text-rendering: optimizeLegibility; font-size: clamp(0.9rem, 1.8vw, 1.1rem); line-height: 1.22; opacity: 0; pointer-events: none; max-width: clamp(480px, 48vw, 720px); height: var(--box-h); gap: var(--gap-px); transform: translateY(6px); transition: opacity .45s ease, transform .45s ease; }
 .hero-subtitle--fixed { position: fixed; left: clamp(12px, 2vw, 20px); bottom: calc(clamp(12px, 2vw, 20px) + env(safe-area-inset-bottom)); opacity: 0.82; transform: translateY(0); }
@@ -129,14 +125,9 @@ body.reduce-motion .particle-canvas { opacity: .6; }
 	.floating-icon, .hero-image-decoration { display: none; }
 }
 /* Print: Hero-spezifische Deaktivierungen */
-@media print { .hero-background { display: none !important; } }
 
 </style>
 <div class="section hero" id="hero">
-  <div class="hero-background">
-    <div class="gradient-overlay"></div>
-    <canvas class="particle-canvas" id="particleCanvas"></canvas>
-  </div>
   <div class="container hero-content">
   <p class="hero-subtitle" data-offset-mode="full">
       <span id="typedAuthor" class="typed-author"></span>

--- a/content/webentwicklung/index.css
+++ b/content/webentwicklung/index.css
@@ -95,7 +95,7 @@ body {
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 body {
   font-family: var(--font-primary);
-  background: var(--bg-dark);
+  background: transparent;
   color: var(--text-primary);
   margin: 0;
   text-rendering: optimizeLegibility;
@@ -103,6 +103,56 @@ body {
 font-kerning: normal;
 font-variant-ligatures: common-ligatures contextual;
 font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
+}
+
+/* Global fixed background layer */
+#site-bg{
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+#site-bg::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background: url('/img/dein-hintergrund.jpg') center/cover no-repeat;
+  filter: none;
+}
+
+#site-bg .gradient-overlay{
+  position:absolute;
+  inset:0;
+  background: radial-gradient(120% 80% at 50% 40%,
+              rgba(255,255,255,0.05) 0%,
+              rgba(9,139,255,0.10) 35%,
+              rgba(0,0,0,0.55) 100%);
+  mix-blend-mode: normal;
+}
+
+#site-bg .particle-canvas{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  opacity:.45;
+}
+
+.main-header, #menu-container, .back-to-top, .loading-screen {
+  position: relative;
+  z-index: 2;
+}
+
+.hero,
+.features,
+.projects,
+.skills,
+.about,
+.contact,
+.footer {
+  background: transparent;
 }
 
 
@@ -124,6 +174,12 @@ font-feature-settings: "kern" 1, "liga" 1, "calt" 1;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  position: relative;
+  z-index: 1;
+}
+
+.section .container{
+  background: transparent;
 }
 
 .section-inner {
@@ -278,7 +334,7 @@ a:hover { color: var(--primary-light); }
   box-sizing: border-box;
   justify-content: center;
   align-items: center;
-  background: var(--bg-section);
+  background: transparent;
 }
 
 .project-filter {
@@ -360,7 +416,7 @@ a:hover { color: var(--primary-light); }
   box-sizing: border-box;
   justify-content: center;
   align-items: center;
-  background: var(--bg-section);
+  background: transparent;
 }
 
 .skills-grid,
@@ -400,7 +456,7 @@ a:hover { color: var(--primary-light); }
   box-sizing: border-box;
   justify-content: center;
   align-items: center;
-  background: var(--bg-section);
+  background: transparent;
 }
 
 /* -- Contact -- */
@@ -411,7 +467,7 @@ a:hover { color: var(--primary-light); }
   box-sizing: border-box;
   justify-content: center;
   align-items: center;
-  background: var(--bg-section);
+  background: transparent;
 }
 
 .contact-content {
@@ -559,7 +615,7 @@ a:hover { color: var(--primary-light); }
    9) Print
 ======================================== */
 @media print {
-  .loading-screen, .main-header, .hero-background, .project-filter, .back-to-top { display: none !important; }
+  .loading-screen, .main-header, .project-filter, .back-to-top { display: none !important; }
   body { color: black; background: white; font-size: 12pt; }
   .container { max-width: 900px; margin: 0 auto; width: 100%; }
   a { color: black; text-decoration: underline; }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
   <title>Abdulkerim - Digital Portfolio</title>
 </head>
 <body>
+  <!-- Global Fixed Background -->
+  <div id="site-bg" aria-hidden="true">
+    <canvas class="particle-canvas" id="particleCanvas"></canvas>
+    <div class="gradient-overlay"></div>
+  </div>
+
   <!-- Menü (dynamisch geladen) -->
   <div id="menu-container"></div>
 


### PR DESCRIPTION
## Summary
- Add fixed `#site-bg` layer for shared particle and gradient backdrop
- Remove hero-specific background container and make all sections transparent
- Ensure features and footer sections no longer cover global background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a58f64428832e9a3fdc53ee1d9398