### PR TITLE
Reset AOS elements when leaving viewport

### DIFF
--- a/content/webentwicklung/main.js
+++ b/content/webentwicklung/main.js
@@ -283,7 +283,13 @@ function initScrollAnimations() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   });
   const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('aos-animate'); });
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('aos-animate');
+      } else {
+        entry.target.classList.remove('aos-animate');
+      }
+    });
   }, { threshold: 0.1, rootMargin: '0px 0px -50px 0px' });
   document.querySelectorAll('[data-aos]').forEach(el => observer.observe(el));
 }
@@ -435,7 +441,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   initScrollAnimations();
 
   // Performance: Scroll-Handler (nach geladener timing.js)
-  window.addEventListener('scroll', debounce(handleScrollEvents, 75));
+  window.addEventListener('scroll', debounce(handleScrollEvents, 75), { passive: true });
   handleScrollEvents();
 
   // Smooth Anchor Scroll


### PR DESCRIPTION
## Summary
- Restore `data-aos` elements to their hidden state when they exit the viewport
- Use a passive scroll listener for the back-to-top button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ade0d41dc832e9d575f6d1c2c25be