### PR TITLE
feat: opacity animations with vertical scroll movement

### DIFF
--- a/content/webentwicklung/animations.js
+++ b/content/webentwicklung/animations.js
@@ -126,7 +126,7 @@
 
     // will-change nur kurz
     const prevWill = el.style.willChange;
-    el.style.willChange = 'opacity';
+    el.style.willChange = 'opacity, transform';
 
     const tId = setTimeout(() => {
       el.classList.add('is-visible');

--- a/content/webentwicklung/main.js
+++ b/content/webentwicklung/main.js
@@ -491,21 +491,24 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const NEAR_ZERO = 0.04; // Klickschutz-Schwelle
 
-    function applyOpacity(){
-      const vh = window.innerHeight;
-      const start = vh * 0.55; // ab hier beginnt Ausfaden
-      const end   = vh * 0.10; // hier 0
+      function applyOpacity(){
+        const vh = window.innerHeight;
+        const start = vh * 0.55; // ab hier beginnt Ausfaden
+        const end   = vh * 0.10; // hier 0
+        const maxShift = 40;     // maximale Verschiebung nach oben in px
 
-      for (const el of fadeEls) {
-        const r = el.getBoundingClientRect();
-        const mid = r.top + r.height/2;
-        let t = (mid - end) / (start - end); // 1..0
-        if (t > 1) t = 1; else if (t < 0) t = 0;
+        for (const el of fadeEls) {
+          const r = el.getBoundingClientRect();
+          const mid = r.top + r.height/2;
+          let t = (mid - end) / (start - end); // 1..0
+          if (t > 1) t = 1; else if (t < 0) t = 0;
 
-        el.style.opacity = t.toFixed(3);
-        el.style.pointerEvents = (t < NEAR_ZERO) ? 'none' : '';
+          const shift = (1 - t) * -maxShift; // 0..-maxShift
+          el.style.opacity = t.toFixed(3);
+          el.style.transform = t === 1 ? '' : `translateY(${shift.toFixed(1)}px)`;
+          el.style.pointerEvents = (t < NEAR_ZERO) ? 'none' : '';
+        }
       }
-    }
 
     const onScroll = () => applyOpacity();
     const onResize = () => applyOpacity();


### PR DESCRIPTION
## Summary
- update scroll-fade helper to translate elements vertically as they fade
- mark animation elements with `will-change: opacity, transform` for smoother movement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af7bab1e0832eb6830c9256492138