### PR TITLE
Reinitialize scroll animations after hero loads

### DIFF
--- a/content/webentwicklung/home/hero.js
+++ b/content/webentwicklung/home/hero.js
@@ -20,4 +20,7 @@ document.addEventListener('hero:loaded', () => {
     const canvas = document.getElementById('particleCanvas');
     if(canvas && !canvas.__initialized){ initParticles(); canvas.__initialized = true; }
   }
+  if (typeof initScrollAnimations === 'function') {
+    initScrollAnimations();
+  }
 });


### PR DESCRIPTION
## Summary
- Restart scroll-triggered animations when hero section is dynamically loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b11ed92f4832eb1588be5ef5c94ba