### PR TITLE
Escape ampersand in font URLs

### DIFF
--- a/content/webentwicklung/menu/menu.html
+++ b/content/webentwicklung/menu/menu.html
@@ -1,7 +1,7 @@
 <!-- Font Awesome CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/all.min.css">
     <!-- Google Fonts: Lobster -->
-    <link href="https://fonts.googleapis.com/css2?family=Lobster&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lobster&amp;display=swap" rel="stylesheet">
     <!-- Eigene Styles -->
     <link rel="stylesheet" href="/content/webentwicklung/menu/menu.css">
 
@@ -60,5 +60,3 @@
         </ul>
       </nav>
     </header>
-</body>
-</html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <link rel="manifest" href="/manifest.json">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&amp;display=swap">
   <link rel="stylesheet" href="/content/webentwicklung/index.css">
   <link rel="stylesheet" href="/content/webentwicklung/menu/menu.css">
   <link rel="stylesheet" href="/pages/features/feature-rotation.css">


### PR DESCRIPTION
## Summary
- fix unescaped ampersands in Google Fonts URLs
- drop stray closing tags from menu snippet

## Testing
- `tidy -q index.html`
- `tidy -q content/webentwicklung/menu/menu.html`


------
https://chatgpt.com/codex/tasks/task_e_689ee6a7a820832e905c15c54d409939