### PR TITLE
Reduce card size for mobile devices

### DIFF
--- a/pages/features/features-templates.html
+++ b/pages/features/features-templates.html
@@ -116,16 +116,17 @@
     .features{ padding:1.5rem 0 1.75rem; }
     .section-header{ margin-bottom:1.75rem; }
     .features-cards{ grid-template-columns:1fr; gap:.65rem; max-width:100%; }
-    .features .card{ padding:.85rem .95rem .95rem; }
-    .card-title{ font-size:1.05rem; }
-    .card-text{ font-size:.9rem; line-height:1.5; }
+    .features .card{ padding:.7rem .8rem .8rem; }
+    .icon-wrapper{ width:40px; height:40px; }
+    .card-title{ font-size:.95rem; }
+    .card-text{ font-size:.85rem; line-height:1.45; }
   }
 
   @media (max-width:480px){
-    .features .card{ padding:.75rem .85rem .85rem; }
-    .icon-wrapper{ width:46px; height:46px; }
-    .card-title{ font-size:1rem; }
-    .card-text{ font-size:.85rem; }
+    .features .card{ padding:.6rem .7rem .7rem; }
+    .icon-wrapper{ width:36px; height:36px; }
+    .card-title{ font-size:.85rem; }
+    .card-text{ font-size:.8rem; }
   }
 
   @media (min-width:769px) and (max-width:1024px){


### PR DESCRIPTION
## Summary
- decrease padding, icon size, and text sizes of feature cards at small breakpoints for a leaner mobile view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a104bb4250832e808d7664e5fd5d44