### PR TITLE
Shrink feature elements for mobile view

### DIFF
--- a/pages/features/features-templates.html
+++ b/pages/features/features-templates.html
@@ -34,8 +34,13 @@
      Section & Layout
   ======================= */
   .features{
-    display:flex;flex-direction:column;align-items:center;justify-content:center;
-    background:transparent;min-height:100vh;padding:2rem 0;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:flex-start;
+    background:transparent;
+    min-height:100vh;
+    padding:1rem 0 2rem;
   }
 
   .features-content{
@@ -60,6 +65,7 @@
   .features .card{
     position:relative; overflow:hidden;
     display:flex; flex-direction:column; gap:.75rem;
+    justify-content:center;
     padding:var(--card-pad);
     background:rgba(255,255,255,.06);
     border:1px solid rgba(255,255,255,.1);
@@ -113,20 +119,20 @@
      Responsive
   ======================= */
   @media (max-width:768px){
-    .features{ padding:1.5rem 0 1.75rem; }
+    .features{ padding:.75rem 0 1.75rem; }
     .section-header{ margin-bottom:1.75rem; }
     .features-cards{ grid-template-columns:1fr; gap:.65rem; max-width:100%; }
-    .features .card{ padding:.7rem .8rem .8rem; }
-    .icon-wrapper{ width:40px; height:40px; }
-    .card-title{ font-size:.95rem; }
-    .card-text{ font-size:.85rem; line-height:1.45; }
+    .features .card{ padding:.65rem .75rem .75rem; }
+    .icon-wrapper{ width:36px; height:36px; }
+    .card-title{ font-size:.9rem; }
+    .card-text{ font-size:.8rem; line-height:1.45; }
   }
 
   @media (max-width:480px){
-    .features .card{ padding:.6rem .7rem .7rem; }
-    .icon-wrapper{ width:36px; height:36px; }
-    .card-title{ font-size:.85rem; }
-    .card-text{ font-size:.8rem; }
+    .features .card{ padding:.5rem .6rem .6rem; }
+    .icon-wrapper{ width:32px; height:32px; }
+    .card-title{ font-size:.8rem; }
+    .card-text{ font-size:.75rem; line-height:1.4; }
   }
 
   @media (min-width:769px) and (max-width:1024px){


### PR DESCRIPTION
## Summary
- shrink features card padding, icon, and text sizes on mobile breakpoints
- center feature card content vertically within each card
- remove extra top spacing in features section so cards align closer to the top of the viewport
- add slight top padding back to features section so cards aren't flush against the viewport edge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25baf6cec832ea98b3473d8ac920a