### PR TITLE
Add backdrop blur to feature cards

### DIFF
--- a/pages/features/features-templates.html
+++ b/pages/features/features-templates.html
@@ -237,6 +237,8 @@ body{
   border:1px solid rgba(255,255,255,.1);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow-md);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
   transition:transform var(--t), box-shadow var(--t), border-color var(--t), background var(--t);
 }
 


### PR DESCRIPTION
## Summary
- add `backdrop-filter` and `-webkit-backdrop-filter` to feature cards for blurred background effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a42140f0d4832ea89b76159fd67e44