### PR TITLE
Fix feature card backdrop blur

### DIFF
--- a/pages/features/features-templates.html
+++ b/pages/features/features-templates.html
@@ -233,11 +233,13 @@ body{
   justify-content:center;
 
   padding:var(--card-pad);
-  background:rgba(255,255,255,.06);
+  background-color:rgba(255,255,255,.06);
   border:1px solid rgba(255,255,255,.1);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow-md);
-  transition:transform var(--t), box-shadow var(--t), border-color var(--t), background var(--t);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  transition:transform var(--t), box-shadow var(--t), border-color var(--t), background-color var(--t);
 }
 
 .features .card::before{
@@ -255,7 +257,7 @@ body{
   transform:translateY(-6px);
   box-shadow:var(--shadow-lg);
   border-color:rgba(9,139,255,.3);
-  background:rgba(255,255,255,.08);
+  background-color:rgba(255,255,255,.08);
 }
 .features .card:hover::before{ transform:scaleX(1); }
 


### PR DESCRIPTION
## Summary
- use `background-color` on feature cards to ensure backdrop filter applies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42140f0d4832ea89b76159fd67e44