### PR TITLE
Add backdrop blur to index feature cards

### DIFF
--- a/content/webentwicklung/particles/particles.css
+++ b/content/webentwicklung/particles/particles.css
@@ -1,7 +1,7 @@
 .global-particle-background{
   position:fixed; inset:0; z-index:-10; pointer-events:none;
   isolation:isolate; /* verhindert Blend-Effekte mit fremden Stacking-Contexts */
-  contain:layout paint; /* Canvas ist komplett eigenständig */
+  contain:layout; /* nur Layout-Kapselung, erlaubt Backdrop-Filter */
 }
 .global-particle-background .particle-canvas{
   position:absolute; inset:0; width:100%; height:100%;

--- a/pages/features/features-templates.html
+++ b/pages/features/features-templates.html
@@ -233,11 +233,18 @@ body{
   justify-content:center;
 
   padding:var(--card-pad);
-  background:rgba(255,255,255,.06);
+  background-color:rgba(255,255,255,.06);
   border:1px solid rgba(255,255,255,.1);
   border-radius:var(--radius-lg);
   box-shadow:var(--shadow-md);
   transition:transform var(--t), box-shadow var(--t), border-color var(--t), background var(--t);
+}
+
+@supports ((-webkit-backdrop-filter:none) or (backdrop-filter:none)){
+  .features .card{
+    -webkit-backdrop-filter:blur(10px);
+    backdrop-filter:blur(10px);
+  }
 }
 
 .features .card::before{


### PR DESCRIPTION
## Summary
- add CSS backdrop blur to feature cards on index
- remove paint containment from particle background so blur is visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42cbcb6b0832eaf636c7f72bacfcc