### PR TITLE
fix: remove invalid comment from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
-    "test:ui": "vitest --ui"              // optional, nur lokal nutzen
+    "test:ui": "vitest --ui"
   },
   "devDependencies": {
     "vitest": "^3.2.4",


### PR DESCRIPTION
## Summary
- remove JSON comment in package.json so npm can parse it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c329a7c4832ea5ef242a444fb848