### PR TITLE
Expand shuffle tests

### DIFF
--- a/content/webentwicklung/utils/common-utils.js
+++ b/content/webentwicklung/utils/common-utils.js
@@ -25,6 +25,9 @@ export function throttle(func, limit = 250) {
 
 // ===== Array Utilities =====
 export function shuffle(array) {
+  if (!Array.isArray(array)) {
+    throw new TypeError('Input must be an array');
+  }
   const arr = [...array]; // Kopie erstellen
   for (let i = arr.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/tests/utils/shuffle.test.js
+++ b/tests/utils/shuffle.test.js
@@ -1,18 +1,77 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shuffle } from '../../content/webentwicklung/utils/common-utils.js';
+
+// Mock für Math.random, um Aufrufe zu zählen und deterministische Werte zu setzen
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(Math, 'random');
+  Math.random.mockClear();
+});
 
 describe('shuffle', () => {
   it('ändert nicht die Länge und enthält alle Elemente', () => {
-    const input = [1,2,3,4,5];
-    const out = shuffle(input);
-    expect(out).toHaveLength(input.length);
-    expect(out.sort()).toEqual(input.slice().sort());
+    const input = [1, 2, 3, 4, 5];
+    const output = shuffle(input);
+    expect(output).toHaveLength(input.length);
+    expect(output.sort((a, b) => a - b)).toEqual(input.slice().sort((a, b) => a - b));
   });
 
   it('ruft Math.random mehrfach auf', () => {
-    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
-    shuffle([1,2,3,4,5]);
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
+    Math.random.mockReturnValue(0.1);
+    shuffle([1, 2, 3, 4, 5]);
+    expect(Math.random).toHaveBeenCalled();
+    expect(Math.random).toHaveBeenCalledTimes(4); // n-1 Aufrufe
+  });
+
+  it('mutiert das Eingabe-Array nicht', () => {
+    const input = [1, 2, 3, 4, 5];
+    const inputCopy = [...input];
+    shuffle(input);
+    expect(input).toEqual(inputCopy);
+  });
+
+  it('gibt ein leeres Array für leere Eingabe zurück', () => {
+    const output = shuffle([]);
+    expect(output).toEqual([]);
+    expect(Math.random).not.toHaveBeenCalled();
+  });
+
+  it('gibt Array mit einem Element unverändert zurück', () => {
+    const input = [42];
+    const output = shuffle(input);
+    expect(output).toEqual([42]);
+    expect(Math.random).not.toHaveBeenCalled();
+  });
+
+  it('liefert deterministische Reihenfolge bei festem Math.random', () => {
+    Math.random.mockReturnValue(0.5);
+    const input = [1, 2, 3, 4, 5];
+    const output = shuffle(input);
+    expect(output).toEqual([1, 4, 2, 5, 3]);
+  });
+
+  it('funktioniert mit verschiedenen Datentypen', () => {
+    const input = [1, 'hello', { id: 1 }, null, undefined];
+    const output = shuffle(input);
+    expect(output).toHaveLength(input.length);
+    expect(output.sort()).toEqual(input.slice().sort());
+  });
+
+  it('wirft Fehler bei ungültiger Eingabe', () => {
+    expect(() => shuffle(null)).toThrow();
+    expect(() => shuffle(undefined)).toThrow();
+    expect(() => shuffle('not an array')).toThrow();
+    expect(() => shuffle(123)).toThrow();
+  });
+
+  it('liefert unterschiedliche Reihenfolgen bei mehrfachen Aufrufen', () => {
+    const input = [1, 2, 3, 4, 5];
+    const outputs = new Set();
+    for (let i = 0; i < 10; i++) {
+      const output = shuffle([...input]).join(',');
+      outputs.add(output);
+    }
+    expect(outputs.size).toBeGreaterThan(1);
   });
 });
+


### PR DESCRIPTION
## Summary
- add input validation to shuffle to enforce array inputs
- expand shuffle tests with edge cases, randomization checks, and determinism

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5e453f8832e8f269a38b48cbc74