### PR TITLE
Fix section scroll snap registration

### DIFF
--- a/content/webentwicklung/animations/animation.js
+++ b/content/webentwicklung/animations/animation.js
@@ -53,6 +53,29 @@ const checkReducedMotionAnimations = () => {
     // Nur noch CSS-Snap verwenden, keine JS-Handler mehr
     // Snap-Logik und Event-Handler entfernt
 
+    // Alle Sections als Snap-Targets registrieren und Observer einrichten
+    snapSections = Array.from(document.querySelectorAll('section'));
+    snapSections.forEach((el, idx) => {
+      el.classList.add('snap-section');
+      if (idx === 0) el.classList.add('section-active');
+    });
+
+    snapObserver = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        const newIndex = snapSections.indexOf(entry.target);
+        if (newIndex === -1 || newIndex === currentSnapIndex) continue;
+        snapSections[currentSnapIndex]?.classList.remove('section-active');
+        currentSnapIndex = newIndex;
+        entry.target.classList.add('section-active');
+        window.dispatchEvent(new CustomEvent('snapSectionChange', {
+          detail: { index: currentSnapIndex, id: entry.target.id }
+        }));
+      }
+    }, { threshold: 0.6 });
+
+    snapSections.forEach(s => snapObserver.observe(s));
+
     const scrollToSection = (targetIndex) => {
       let clampedIndex = clamp(targetIndex, 0, snapSections.length - 1);
 


### PR DESCRIPTION
## Summary
- register all sections for scroll snapping with IntersectionObserver
- dispatch `snapSectionChange` on active section updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a704bcfbf8832e9ab0fc7a0add6c77