### PR TITLE
Reorder hero layout for correct animation sequence

### DIFF
--- a/pages/home/hero.html
+++ b/pages/home/hero.html
@@ -108,8 +108,8 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
 }
 /* Tablet & <=1024px */
 @media (max-width: 1024px) {
-	.hero-content { grid-template-columns: 1fr; text-align: center; }
-	.hero-visual { order: -1; margin-bottom: var(--spacing-xl); }
+        .hero-content { grid-template-columns: 1fr; text-align: center; }
+        .hero-visual { margin-bottom: var(--spacing-xl); }
 }
 /* Mobile <=768px */
 @media (max-width: 768px){
@@ -134,13 +134,6 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
 <div class="section hero" id="hero">
   <div class="container hero-content">
   <!-- hero-subtitle global in index.html verschoben -->
-    <div class="hero-buttons" data-stagger-group="hero-btns" data-stagger-step="120" data-stagger-base="360">
-
-            <a href="#projects" class="btn btn-primary btn-crt" data-animation="crt">Projekte entdecken</a>
-      <a href="/content/kontakt/" class="btn btn-secondary btn-crt" data-animation="crt">Kontakt</a>
-
-
-    </div>
     <div class="hero-visual">
       <div class="hero-image-container">
         <div class="spotlight-bg"></div>
@@ -152,6 +145,13 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
           <div class="floating-icon delay-3"><span>🎨</span></div>
         </div>
       </div>
+    </div>
+    <div class="hero-buttons" data-stagger-group="hero-btns" data-stagger-step="120" data-stagger-base="360">
+
+            <a href="#projects" class="btn btn-primary btn-crt" data-animation="crt">Projekte entdecken</a>
+      <a href="/content/kontakt/" class="btn btn-secondary btn-crt" data-animation="crt">Kontakt</a>
+
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Reorder hero section markup so visual block renders before buttons, fixing animation order
- Drop flexbox `order` hack for hero visual at tablet sizes to rely on natural DOM order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a794935344832e9aa55469d32cd192