### PR TITLE
Ensure hero greeting initializes after hero markup loads

### DIFF
--- a/content/webentwicklung/main.js
+++ b/content/webentwicklung/main.js
@@ -159,6 +159,13 @@ const checkReducedMotion = () => {
     else el.textContent = next;
   }
 
+  // Sicherstellen, dass der Gruß nach dem Laden des Hero-Markups gesetzt wird
+  document.addEventListener('hero:loaded', () => {
+    const el = getElement("greetingText");
+    if (!el || el.textContent) return;
+    setRandomGreetingHTML();
+  });
+
   // ===== Menü-Assets on demand =====
   function loadMenuAssets(){
     const c = getElement("menu-container");


### PR DESCRIPTION
## Summary
- Set greeting text when `hero:loaded` fires to avoid missing text when hero markup loads asynchronously

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ea9c7d38832e826f5b647764dd7b