### PR TITLE
Improve greeting text responsiveness

### DIFF
--- a/pages/about/about.html
+++ b/pages/about/about.html
@@ -79,7 +79,7 @@ body:not(.has-typingjs) .hero-subtitle .typed-text{ display:inline-block; white-
 body:not(.hero-active) .greeting-text-hero, body.reduce-motion .greeting-text-hero { animation-play-state: paused !important; }
 body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { animation-play-state: paused !important; }
 .spotlight-bg { position: absolute; top: 55%; left: 50%; transform: translate(-50%, -50%) rotate(-8deg); width: 120%; height: 60%; background: radial-gradient(ellipse at center, #fff5 0%, #098bff22 55%, transparent 100%); filter: blur(22px); z-index: 1; pointer-events: none; }
-.greeting-text-hero { --greet-fs: clamp(1.6rem, 3.6vw, 2.4rem); --greet-lh: 1.14; --greet-weight: 600; --greet-letter: -0.012em; --greet-max: clamp(16ch, 40vw, 24ch); --greet-grad: linear-gradient(90deg, #07a1ff, #35e0ff 78%); --greet-anim-grad-dur: 16.5s; --greet-anim-pulse-dur: 13.2s; position: absolute; font-family: 'Inter', 'Segoe UI', Arial, sans-serif; font-size: var(--greet-fs); line-height: var(--greet-lh); font-weight: var(--greet-weight); letter-spacing: var(--greet-letter); text-align: center; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; margin: 32px 0 0 0; padding: 0 10px; background: var(--greet-grad); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent; opacity: 1; -webkit-user-select: none; user-select: none; white-space: normal; overflow-wrap: anywhere; word-break: normal; -webkit-hyphens: auto; hyphens: auto; max-width: var(--greet-max); min-height: 2.6em; font-variation-settings: "opsz" 18; font-optical-sizing: auto; animation: gradientMove var(--greet-anim-grad-dur) linear infinite, pulseGlow var(--greet-anim-pulse-dur) ease-in-out infinite; }
+.greeting-text-hero { --greet-fs: clamp(1.25rem, calc(0.5rem + 4vw), 2.8rem); --greet-lh: 1.14; --greet-weight: 600; --greet-letter: -0.012em; --greet-max: clamp(16ch, 40vw, 24ch); --greet-grad: linear-gradient(90deg, #07a1ff, #35e0ff 78%); --greet-anim-grad-dur: 16.5s; --greet-anim-pulse-dur: 13.2s; position: absolute; font-family: 'Inter', 'Segoe UI', Arial, sans-serif; font-size: var(--greet-fs); line-height: var(--greet-lh); font-weight: var(--greet-weight); letter-spacing: var(--greet-letter); text-align: center; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; margin: 32px 0 0 0; padding: 0 10px; background: var(--greet-grad); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent; opacity: 1; -webkit-user-select: none; user-select: none; white-space: normal; overflow-wrap: anywhere; word-break: normal; -webkit-hyphens: auto; hyphens: auto; max-width: var(--greet-max); min-height: 2.6em; font-variation-settings: "opsz" 18; font-optical-sizing: auto; animation: gradientMove var(--greet-anim-grad-dur) linear infinite, pulseGlow var(--greet-anim-pulse-dur) ease-in-out infinite; }
 .greeting-text-hero--alt { --greet-grad: linear-gradient(92deg,#fff,#d2efff 60%); --greet-anim-grad-dur: 9s; --greet-anim-pulse-dur: 4.4s; filter: drop-shadow(0 3px 18px rgba(0,180,255,.35)); }
 .greeting-text-hero[data-animation] { will-change: opacity, transform; }
 .greeting-text-hero[data-animation].animate-element { opacity: 0; animation-play-state: paused; }
@@ -103,7 +103,7 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
 	.hero-subtitle .typed-text{ font-size: 0.80em; line-height: 1.16; letter-spacing: 0.001em; }
 	.hero-subtitle .typed-author{ font-size: clamp(0.82rem, 1.1vw, 0.94rem); }
 	.hero-subtitle .typed-text::after{ height: 0.86em; border-left-width: 2px; margin-left: 0.08ch; }
-	.greeting-text-hero{ --greet-fs: clamp(1.5rem, 2.6vw, 2.2rem); --greet-lh: 1.12; --greet-letter: -0.014em; --greet-max: clamp(18ch, 36vw, 24ch); }
+	.greeting-text-hero{ --greet-lh: 1.12; --greet-letter: -0.014em; --greet-max: clamp(18ch, 36vw, 24ch); }
 	.hero-buttons { position: static; display: flex; justify-content: center; gap: var(--spacing-md); margin-top: clamp(1.2rem, 4vh, 2rem); pointer-events: auto; }
 }
 /* Tablet & <=1024px */
@@ -124,7 +124,7 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
 	.hero-subtitle .typed-text{ font-size: 0.82em; line-height: 1.14; letter-spacing: 0.001em; text-shadow: none; opacity: 0.8; }
 	.hero-subtitle .typed-author{ font-size: clamp(0.80rem, 1.8vw, 0.92rem); }
 	.hero-subtitle .typed-text::after{ height: 0.82em; border-left-width: 2px; margin-left: 0.06ch; }
-	.greeting-text-hero{ --greet-fs: clamp(1.35rem, 5.2vw, 1.85rem); --greet-lh: 1.16; --greet-letter: -0.01em; --greet-max: clamp(18ch, 78vw, 26ch); --greet-anim-grad-dur: 7.5s; --greet-anim-pulse-dur: 3.6s; margin-top: 20px; }
+	.greeting-text-hero{ --greet-lh: 1.16; --greet-letter: -0.01em; --greet-max: clamp(18ch, 78vw, 26ch); --greet-anim-grad-dur: 7.5s; --greet-anim-pulse-dur: 3.6s; margin-top: 20px; }
 	.floating-icon, .hero-image-decoration { display: none; }
 }
 /* Print: Hero-spezifische Deaktivierungen */

--- a/pages/home/hero.html
+++ b/pages/home/hero.html
@@ -79,7 +79,7 @@ body:not(.has-typingjs) .hero-subtitle .typed-text{ display:inline-block; white-
 body:not(.hero-active) .greeting-text-hero, body.reduce-motion .greeting-text-hero { animation-play-state: paused !important; }
 body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { animation-play-state: paused !important; }
 .spotlight-bg { position: absolute; top: 55%; left: 50%; transform: translate(-50%, -50%) rotate(-8deg); width: 120%; height: 60%; background: radial-gradient(ellipse at center, #fff5 0%, #098bff22 55%, transparent 100%); filter: blur(22px); z-index: 1; pointer-events: none; }
-.greeting-text-hero { --greet-fs: clamp(1.6rem, 3.6vw, 2.4rem); --greet-lh: 1.14; --greet-weight: 600; --greet-letter: -0.012em; --greet-max: clamp(16ch, 40vw, 24ch); --greet-grad: linear-gradient(90deg, #07a1ff, #35e0ff 78%); --greet-anim-grad-dur: 16.5s; --greet-anim-pulse-dur: 13.2s; position: absolute; font-family: 'Inter', 'Segoe UI', Arial, sans-serif; font-size: var(--greet-fs); line-height: var(--greet-lh); font-weight: var(--greet-weight); letter-spacing: var(--greet-letter); text-align: center; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; margin: 32px 0 0 0; padding: 0 10px; background: var(--greet-grad); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent; opacity: 1; -webkit-user-select: none; user-select: none; white-space: normal; overflow-wrap: anywhere; word-break: normal; -webkit-hyphens: auto; hyphens: auto; max-width: var(--greet-max); min-height: 2.6em; font-variation-settings: "opsz" 18; font-optical-sizing: auto; animation: gradientMove var(--greet-anim-grad-dur) linear infinite, pulseGlow var(--greet-anim-pulse-dur) ease-in-out infinite; }
+.greeting-text-hero { --greet-fs: clamp(1.25rem, calc(0.5rem + 4vw), 2.8rem); --greet-lh: 1.14; --greet-weight: 600; --greet-letter: -0.012em; --greet-max: clamp(16ch, 40vw, 24ch); --greet-grad: linear-gradient(90deg, #07a1ff, #35e0ff 78%); --greet-anim-grad-dur: 16.5s; --greet-anim-pulse-dur: 13.2s; position: absolute; font-family: 'Inter', 'Segoe UI', Arial, sans-serif; font-size: var(--greet-fs); line-height: var(--greet-lh); font-weight: var(--greet-weight); letter-spacing: var(--greet-letter); text-align: center; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; margin: 32px 0 0 0; padding: 0 10px; background: var(--greet-grad); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent; opacity: 1; -webkit-user-select: none; user-select: none; white-space: normal; overflow-wrap: anywhere; word-break: normal; -webkit-hyphens: auto; hyphens: auto; max-width: var(--greet-max); min-height: 2.6em; font-variation-settings: "opsz" 18; font-optical-sizing: auto; animation: gradientMove var(--greet-anim-grad-dur) linear infinite, pulseGlow var(--greet-anim-pulse-dur) ease-in-out infinite; }
 .greeting-text-hero--alt { --greet-grad: linear-gradient(92deg,#fff,#d2efff 60%); --greet-anim-grad-dur: 9s; --greet-anim-pulse-dur: 4.4s; filter: drop-shadow(0 3px 18px rgba(0,180,255,.35)); }
 .greeting-text-hero[data-animation] { will-change: opacity, transform; }
 .greeting-text-hero[data-animation].animate-element { opacity: 0; animation-play-state: paused; }
@@ -103,7 +103,7 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
 	.hero-subtitle .typed-text{ font-size: 0.80em; line-height: 1.16; letter-spacing: 0.001em; }
 	.hero-subtitle .typed-author{ font-size: clamp(0.82rem, 1.1vw, 0.94rem); }
 	.hero-subtitle .typed-text::after{ height: 0.86em; border-left-width: 2px; margin-left: 0.08ch; }
-	.greeting-text-hero{ --greet-fs: clamp(1.5rem, 2.6vw, 2.2rem); --greet-lh: 1.12; --greet-letter: -0.014em; --greet-max: clamp(18ch, 36vw, 24ch); }
+	.greeting-text-hero{ --greet-lh: 1.12; --greet-letter: -0.014em; --greet-max: clamp(18ch, 36vw, 24ch); }
 	.hero-buttons { position: static; display: flex; justify-content: center; gap: var(--spacing-md); margin-top: clamp(1.2rem, 4vh, 2rem); pointer-events: auto; }
 }
 /* Tablet & <=1024px */
@@ -124,7 +124,7 @@ body:not(.hero-active) .floating-icon, body.reduce-motion .floating-icon { anima
 	.hero-subtitle .typed-text{ font-size: 0.82em; line-height: 1.14; letter-spacing: 0.001em; text-shadow: none; opacity: 0.8; }
 	.hero-subtitle .typed-author{ font-size: clamp(0.80rem, 1.8vw, 0.92rem); }
 	.hero-subtitle .typed-text::after{ height: 0.82em; border-left-width: 2px; margin-left: 0.06ch; }
-	.greeting-text-hero{ --greet-fs: clamp(1.35rem, 5.2vw, 1.85rem); --greet-lh: 1.16; --greet-letter: -0.01em; --greet-max: clamp(18ch, 78vw, 26ch); --greet-anim-grad-dur: 7.5s; --greet-anim-pulse-dur: 3.6s; margin-top: 20px; }
+	.greeting-text-hero{ --greet-lh: 1.16; --greet-letter: -0.01em; --greet-max: clamp(18ch, 78vw, 26ch); --greet-anim-grad-dur: 7.5s; --greet-anim-pulse-dur: 3.6s; margin-top: 20px; }
 	.floating-icon, .hero-image-decoration { display: none; }
 }
 /* Print: Hero-spezifische Deaktivierungen */


### PR DESCRIPTION
## Summary
- use clamp with viewport-based calculation for `.greeting-text-hero` so greeting scales smoothly on all screens
- drop redundant font-size overrides for desktop and mobile

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a80e4ac158832eaeec51cc94d6f226