### PR TITLE
feat: delay hero button animation until scroll end

### DIFF
--- a/content/webentwicklung/main.js
+++ b/content/webentwicklung/main.js
@@ -221,13 +221,34 @@ const checkReducedMotion = () => {
 
     
     
-    setTimeout(()=> {
-      try {
-        const hero=getElement("hero"); if(!hero||!window.AnimationSystem) return;
-        window.AnimationSystem.scan?.();
-        hero.querySelectorAll('.hero-buttons [data-animation="crt"].animate-element:not(.is-visible)')?.forEach(b => b.classList.add("is-visible"));
-      } catch {}
-    }, 420);
+    // Hero Button Animation erst nach Scroll-Ende starten
+    try {
+      const hero = getElement("hero");
+      if (hero && window.AnimationSystem) {
+        const showHeroButtons = () => {
+          if (showHeroButtons.done) return;
+          showHeroButtons.done = true;
+          window.AnimationSystem.scan?.();
+          hero
+            .querySelectorAll(
+              '.hero-buttons [data-animation="crt"].animate-element:not(.is-visible)'
+            )
+            ?.forEach((b) => b.classList.add("is-visible"));
+        };
+
+        let scrollTimer;
+        const onScrollEnd = () => {
+          clearTimeout(scrollTimer);
+          scrollTimer = setTimeout(() => {
+            window.removeEventListener("scroll", onScrollEnd);
+            showHeroButtons();
+          }, 150);
+        };
+
+        window.addEventListener("scroll", onScrollEnd, { passive: true });
+        onScrollEnd(); // Fallback falls kein Scroll erfolgt
+      }
+    } catch {}
 
     // AOS Auto-Delay (nur wenn nicht gesetzt)
     document.querySelectorAll("[data-aos]").forEach((el,i)=> el.hasAttribute("data-aos-delay") || el.setAttribute("data-aos-delay", String(i*50)));


### PR DESCRIPTION
## Summary
- trigger hero button CRT animation only after scroll has stopped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84f8e88e4832eb559d6210c7a4692