### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/coverage/sorter.js
+++ b/coverage/sorter.js
@@ -1,6 +1,15 @@
 /* eslint-disable */
 var addSorting = (function() {
     'use strict';
+    // Escape HTML meta-characters
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
     var cols,
         currentSort = {
             index: 0,
@@ -88,6 +97,8 @@ var addSorting = (function() {
             val = colNode.getAttribute('data-value');
             if (col.type === 'number') {
                 val = Number(val);
+            } else if (val != null) {
+                val = escapeHtml(val);
             }
             data[col.key] = val;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/aKs030/iweb/security/code-scanning/6](https://github.com/aKs030/iweb/security/code-scanning/6)

To mitigate this vulnerability, we must ensure that the value obtained from `colNode.getAttribute('data-value')` is properly sanitized before use, or guarantee that it is never used in a context that interprets it as HTML. The safest general approach is to encode any HTML meta-characters in the value, so any attempt to insert it via `innerHTML` will only display the text and not interpret tags/scripts.  

**How to fix:**  
- At the point where we read `data-value`, encode characters such as `<`, `>`, `"`, `'`, and `&` using a simple escape function.
- Do this immediately after reading the attribute, on line 88, before assigning `val` to the `data` object.

**Files/lines to change:**  
Change the assignment to `val` in `loadRowData()`, near line 88, to perform HTML-encoding.  
Add an encoding function, for example, `escapeHtml`, to the file.  
No changes to imports required, as we can implement encoding inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
