### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-css.yml
+++ b/.github/workflows/check-css.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Check CSS tokens
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/aKs030/iweb/security/code-scanning/4](https://github.com/aKs030/iweb/security/code-scanning/4)

To fix this problem, explicitly declare the required permissions for the workflow. Since the job only checks out code, installs dependencies, and runs tests—operations that only require reading repository contents—it is safe and preferable to limit the workflow to the minimal permission: `contents: read`. This should be set at either the workflow root (to apply to all jobs) or within the job itself (`check-css`). The most maintainable approach is to add this block at the root level, just below the workflow `name:` declaration, to ensure no jobs within this workflow gain unnecessary permissions in the future.

- Change: Add a `permissions: { contents: read }` block at the root level of `.github/workflows/check-css.yml`
- No other edits are required, and no new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
