### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/consolidate-check.yml
+++ b/.github/workflows/consolidate-check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Consolidate tokens check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/aKs030/iweb/security/code-scanning/2](https://github.com/aKs030/iweb/security/code-scanning/2)

To fix this issue, the workflow should explicitly specify appropriate least-privilege permissions using a `permissions` block. The best way to do this is at the top workflow level (outside of `jobs`), which sets the default permissions for all jobs within the workflow. Reviewing the steps, it appears that only build, test, and artifact upload steps are present—no step needs write access to the repository (`contents: write`), so the minimal required permission is likely `contents: read`. If any artifact upload or dependency step required more permission, it could be granted specifically, but for these steps, `contents: read` suffices. 

The change should be made near the top of the file after the `name:` field and before/on the same level as the `on:` block; if other jobs later require more permissions, they can override at the job level as needed. No code changes or imports are needed—just a new YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
