### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete regular expression for hostnames

### DIFF
--- a/scripts/security-scan.js
+++ b/scripts/security-scan.js
@@ -54,7 +54,7 @@ const assetCheck = true; // aktiviert Basis Asset-Existenzprüfung
 // Inline Events: generische Erkennung (vereinfacht für Lint-Rules)
 const inlineEventAttr = / on[a-z]+=/gi;
 const metaSecurity = /<meta[^>]+http-equiv\s*=\s*"(?:Content-Security-Policy|X-Frame-Options|X-Content-Type-Options|X-XSS-Protection)"/gi;
-const externalFontCdn = /(fonts.googleapis.com|use\.fontawesome\.com|cdnjs\.cloudflare\.com|cdn\.jsdelivr\.net|unpkg\.com)/gi;
+const externalFontCdn = /(fonts\.googleapis\.com|use\.fontawesome\.com|cdnjs\.cloudflare\.com|cdn\.jsdelivr\.net|unpkg\.com)/gi;
 const cssImport = /@import\s+url\(/gi;
 const inlineStyleAttr = / style="[^"]+"/gi;
 


### PR DESCRIPTION
Potential fix for [https://github.com/aKs030/iweb/security/code-scanning/8](https://github.com/aKs030/iweb/security/code-scanning/8)

To fix the problem, each `.` in a hostname in a regular expression must be escaped with a backslash (`\.`), so it matches only literal periods and not just any character. In the problematic regex on line 57, `fonts.googleapis.com` and `cdnjs.cloudflare.com` both feature unescaped dots. The best fix is to escape all dots in each domain name in the regex, so only the intended exact CDN hostnames are matched. Only the assignment to `externalFontCdn` (line 57) in scripts/security-scan.js needs to be changed. No extra imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
