### PR TITLE
Restore full footer content by removing scaling

### DIFF
--- a/content/webentwicklung/footer/footer-complete.js
+++ b/content/webentwicklung/footer/footer-complete.js
@@ -632,8 +632,6 @@ class FooterResizer {
       MOBILE_BREAKPOINT: 768,
       MAX_FOOTER_RATIO_MOBILE: 0.7,
       MAX_FOOTER_RATIO_DESKTOP: 0.6,
-      MIN_SCALE_MOBILE: 0.75,
-      MIN_SCALE_DESKTOP: 0.5,
       THROTTLE_DELAY: 150,
     };
     this.lastSnapshot = "";
@@ -704,11 +702,6 @@ class FooterResizer {
     return { h, usable: h };
   }
 
-  computeScale() {
-    const w = Math.max(320, window.innerWidth);
-    return Math.max(0.8, Math.min(1, 0.88 + w / 2000));
-  }
-
   setCSSVar(name, value) {
     const footer = document.getElementById("site-footer");
     const target = footer ?? document.documentElement;
@@ -732,29 +725,16 @@ class FooterResizer {
     const content = document.querySelector("#site-footer .footer-enhanced-content");
     
     if (content) {
-      this.setCSSVar("--footer-scale", "1");
-      void content.offsetHeight; // Force reflow
-
-      const naturalHeight = content.scrollHeight;
-      const base = Math.max(1, naturalHeight || 0);
-      let scale = base > 0 ? Math.min(1, maxFooter / base) : this.computeScale();
-
-      const minScale = isMobile
-        ? this.config.MIN_SCALE_MOBILE
-        : this.config.MIN_SCALE_DESKTOP;
-      scale = Math.max(minScale, Number(scale.toFixed(3)));
-
-      this.setCSSVar("--footer-scale", String(scale));
-      const actual = Math.round(base * scale);
+      const naturalHeight = Math.max(1, content.scrollHeight || 0);
+      const actual = Math.min(naturalHeight, maxFooter);
       this.setCSSVar("--footer-actual-height", `${actual}px`);
 
-      const snapshot = `${scale}|${isMobile}|${maxFooter}|${actual}`;
+      const snapshot = `${naturalHeight}|${isMobile}|${maxFooter}|${actual}`;
       if (this.lastSnapshot !== snapshot) {
-        log.debug(`Scale: ${scale}, Mobile: ${isMobile}, Max: ${maxFooter}px, Actual: ${actual}px`);
+        log.debug(`Content: ${naturalHeight}px, Mobile: ${isMobile}, Max: ${maxFooter}px, Viewport: ${actual}px`);
         this.lastSnapshot = snapshot;
       }
     } else {
-      this.setCSSVar("--footer-scale", String(this.computeScale()));
       this.setCSSVar("--footer-actual-height", `${maxFooter}px`);
     }
   }

--- a/content/webentwicklung/footer/footer.css
+++ b/content/webentwicklung/footer/footer.css
@@ -222,7 +222,10 @@ body.footer-expanded {
 .footer-maximized-viewport {
   height: var(--footer-actual-height, auto);
   max-height: var(--footer-max-height);
-  overflow: clip;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   width: 100%;
 }
 
@@ -232,7 +235,6 @@ body.footer-expanded {
   padding: var(--footer-spacing-lg) var(--footer-spacing-md) 16px;
   box-sizing: border-box;
   transform-origin: top center;
-  transform: scale(var(--footer-scale, 1));
 }
 
 /* ===== Card System ===== */

--- a/content/webentwicklung/index.css
+++ b/content/webentwicklung/index.css
@@ -72,7 +72,8 @@
 /* Base Styles */
 html,
 body {
-  height: 100%;
+  min-height: 100%;
+  height: auto;
   overflow-x: hidden;
   touch-action: pan-y;
   scroll-behavior: smooth;

--- a/content/webentwicklung/root.css
+++ b/content/webentwicklung/root.css
@@ -260,7 +260,6 @@
   --dynamic-footer-text-small: 13px;
   --dynamic-footer-font-weight-medium: 510;
   --dynamic-footer-font-weight-regular: 450;
-  --footer-scale: clamp(0.85, 0.9 + 0.0025vw, 1);
 }
 
 /* =======================


### PR DESCRIPTION
## Summary
- allow the footer resizer to use the natural content height and only clamp to the viewport maximum
- remove the scaling transform and related CSS variable so the expanded footer can display every section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690508eae6108327b96f3e9553520162