### PR TITLE
Fix duplicated section markup in hero and about partials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "iweb",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "iweb",
+      "version": "0.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/pages/about/about.html
+++ b/pages/about/about.html
@@ -7,70 +7,68 @@
   - Dem SVG-Icon wurde ein `<title>`-Element für bessere Barrierefreiheit hinzugefügt, 
     damit Screenreader das Icon beschreiben können.
 -->
-<section class="about" id="about">
-  <div class="about__container">
-    <div class="about__content">
-      <div class="about__text parallax-element" data-parallax-speed="0.1">
-        <h3>Danke für Ihren Besuch!</h3>
+<div class="about__container">
+  <div class="about__content">
+    <div class="about__text parallax-element" data-parallax-speed="0.1">
+      <h3>Danke für Ihren Besuch!</h3>
 
-        <p>
-          Es freut mich sehr, dass Sie sich die Zeit genommen haben, meine Website
-          zu erkunden. Mein Name ist <strong>Abdulkerim</strong> und ich bin ein
-          leidenschaftlicher Webentwickler aus Berlin, der es liebt, digitale
-          Träume in die Realität umzusetzen.
-        </p>
+      <p>
+        Es freut mich sehr, dass Sie sich die Zeit genommen haben, meine Website
+        zu erkunden. Mein Name ist <strong>Abdulkerim</strong> und ich bin ein
+        leidenschaftlicher Webentwickler aus Berlin, der es liebt, digitale
+        Träume in die Realität umzusetzen.
+      </p>
 
-        <p>
-          Hinter jedem Projekt steckt eine Geschichte, hinter jedem Code eine
-          Vision. Ich glaube fest daran, dass großartige Websites mehr sind als
-          nur funktionale Tools – sie sind digitale Erlebnisse, die Menschen
-          bewegen und inspirieren.
-        </p>
+      <p>
+        Hinter jedem Projekt steckt eine Geschichte, hinter jedem Code eine
+        Vision. Ich glaube fest daran, dass großartige Websites mehr sind als
+        nur funktionale Tools – sie sind digitale Erlebnisse, die Menschen
+        bewegen und inspirieren.
+      </p>
 
-        <p>
-          Meine Mission ist es, das Web zu einem schöneren und zugänglicheren Ort
-          zu machen. Dabei verbinde ich moderne Technologien mit kreativem Design
-          und stelle den Menschen stets in den Mittelpunkt meiner Arbeit.
-        </p>
+      <p>
+        Meine Mission ist es, das Web zu einem schöneren und zugänglicheren Ort
+        zu machen. Dabei verbinde ich moderne Technologien mit kreativem Design
+        und stelle den Menschen stets in den Mittelpunkt meiner Arbeit.
+      </p>
 
-        <p>
-          <em>Jede Zeile Code, die ich schreibe, trägt ein Stück meiner Leidenschaft in sich.</em><br />
-          Von der ersten Idee bis zum finalen Launch begleite ich Sie auf Ihrer
-          digitalen Reise.
-        </p>
+      <p>
+        <em>Jede Zeile Code, die ich schreibe, trägt ein Stück meiner Leidenschaft in sich.</em><br />
+        Von der ersten Idee bis zum finalen Launch begleite ich Sie auf Ihrer
+        digitalen Reise.
+      </p>
 
-        <p>
-          Ich hoffe, meine Arbeit konnte Sie inspirieren und Ihnen einen Einblick
-          in meine Welt der Webentwicklung geben. Es war mir eine wahre Freude,
-          Sie hier zu haben.
-        </p>
+      <p>
+        Ich hoffe, meine Arbeit konnte Sie inspirieren und Ihnen einen Einblick
+        in meine Welt der Webentwicklung geben. Es war mir eine wahre Freude,
+        Sie hier zu haben.
+      </p>
 
-        <p class="about__farewell">
-          <strong>Herzlichen Dank für Ihr Interesse und besuchen Sie mich gerne wieder!</strong>
-        </p>
+      <p class="about__farewell">
+        <strong>Herzlichen Dank für Ihr Interesse und besuchen Sie mich gerne wieder!</strong>
+      </p>
 
-        <div class="about__cta">
-          <a href="#hero" class="about__button about__button--primary">Zur Startseite</a>
-          <a href="#contact" class="about__button about__button--outline">
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              aria-hidden="true" 
-              focusable="false"
-            >
-              <title>Lebenslauf herunterladen</title>
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-              <polyline points="7 10 12 15 17 10" />
-              <line x1="12" y1="15" x2="12" y2="3" />
-            </svg>
-            <span>Lebenslauf</span>
-          </a>
-        </div>
+      <div class="about__cta">
+        <a href="#hero" class="about__button about__button--primary">Zur Startseite</a>
+        <a href="#contact" class="about__button about__button--outline">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <title>Lebenslauf herunterladen</title>
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+          <span>Lebenslauf</span>
+        </a>
       </div>
     </div>
   </div>
-</section>
+</div>

--- a/pages/home/hero.html
+++ b/pages/home/hero.html
@@ -1,26 +1,24 @@
-<div class="section hero" id="hero">
-  <div class="container hero-content">
-    <div class="hero-visual">
-      <div class="hero-image-container">
-        <div class="spotlight-bg">
-          <div class="hero-title" id="greetingText">Willkommen</div>
-        </div>
-        <div class="floating-icons">
-          <div class="floating-icon delay-0"><span>⭐️</span></div>
-          <div class="floating-icon delay-1"><span>✨</span></div>
-          <div class="floating-icon delay-2"><span>🌟</span></div>
-          <div class="floating-icon delay-3"><span>✨</span></div>
-        </div>
+<div class="container hero-content">
+  <div class="hero-visual">
+    <div class="hero-image-container">
+      <div class="spotlight-bg">
+        <div class="hero-title" id="greetingText">Willkommen</div>
+      </div>
+      <div class="floating-icons">
+        <div class="floating-icon delay-0"><span>⭐️</span></div>
+        <div class="floating-icon delay-1"><span>✨</span></div>
+        <div class="floating-icon delay-2"><span>🌟</span></div>
+        <div class="floating-icon delay-3"><span>✨</span></div>
       </div>
     </div>
-    <h1 id="hero-heading" class="visually-hidden">
-      Abdulkerim Sesli – Webentwicklung &amp; kreative digitale Projekte
-    </h1>
-    <h2 class="visually-hidden">Portfolio &amp; Dienstleistungen</h2>
   </div>
+  <h1 id="hero-heading" class="visually-hidden">
+    Abdulkerim Sesli – Webentwicklung &amp; kreative digitale Projekte
+  </h1>
+  <h2 class="visually-hidden">Portfolio &amp; Dienstleistungen</h2>
+</div>
 
-  <div class="hero-buttons" data-stagger-group="hero-btns">
-    <a href="#projects" class="btn btn-primary btn-crt">Projekte entdecken</a>
-    <a href="#footer" class="btn btn-secondary btn-crt">Kontakt</a>
-  </div>
+<div class="hero-buttons" data-stagger-group="hero-btns">
+  <a href="#projects" class="btn btn-primary btn-crt">Projekte entdecken</a>
+  <a href="#footer" class="btn btn-secondary btn-crt">Kontakt</a>
 </div>


### PR DESCRIPTION
## Summary
- remove nested wrapper sections with duplicate IDs from the hero and about lazy-loaded partials
- keep hero and about content intact while relying on the existing outer section containers
- add the generated package-lock.json for reproducible installs

## Testing
- npm run audit

------
https://chatgpt.com/codex/tasks/task_e_690639cb9b3c832786c4ca77559af742