### PR TITLE
Improve about CTA fallback and cookie trigger aria

### DIFF
--- a/content/webentwicklung/footer/footer-complete.js
+++ b/content/webentwicklung/footer/footer-complete.js
@@ -257,6 +257,18 @@ const CookieSettings = (() => {
     });
   }
 
+  const COOKIE_TRIGGER_SELECTOR = "[data-cookie-trigger]";
+
+  function setTriggerExpanded(value) {
+    document.querySelectorAll(COOKIE_TRIGGER_SELECTOR).forEach((trigger) => {
+      trigger.setAttribute("aria-expanded", value ? "true" : "false");
+    });
+  }
+
+  function getPrimaryTrigger() {
+    return document.querySelector(COOKIE_TRIGGER_SELECTOR);
+  }
+
   function open() {
     const elements = getElements();
     if (!elements.footer || !elements.cookieView) {
@@ -278,10 +290,7 @@ const CookieSettings = (() => {
     setupSectionObserver(elements);
     setupEventListeners(elements);
     // Accessibility: mark triggers as expanded and move focus into the panel
-    ["footer-cookies-link", "footer-open-cookie-btn"].forEach((id) => {
-      const t = document.getElementById(id);
-      if (t) t.setAttribute("aria-expanded", "true");
-    });
+    setTriggerExpanded(true);
     // Focus first interactive element inside the cookie view
     const firstFocusable = elements.cookieView.querySelector('button, [href], input, select, textarea');
     if (firstFocusable) {
@@ -307,11 +316,8 @@ const CookieSettings = (() => {
     }
     cleanupClickListeners(elements);
     // Accessibility: reset aria-expanded on triggers and return focus
-    ["footer-cookies-link", "footer-open-cookie-btn"].forEach((id) => {
-      const t = document.getElementById(id);
-      if (t) t.setAttribute("aria-expanded", "false");
-    });
-    const trigger = document.getElementById("footer-cookies-link") || document.getElementById("footer-open-cookie-btn");
+    setTriggerExpanded(false);
+    const trigger = getPrimaryTrigger();
     if (trigger) trigger.focus({ preventScroll: true });
     log.info("Cookie settings closed");
   }

--- a/content/webentwicklung/footer/footer-complete.js
+++ b/content/webentwicklung/footer/footer-complete.js
@@ -103,11 +103,12 @@ class ConsentBanner {
     if (this.rejectBtn) {
       this.rejectBtn.addEventListener("click", () => this.reject());
     }
-    if (this.cookiesLink) {
+    if (this.cookiesLink && !this.cookiesLink.dataset.cookieTriggerBound) {
       this.cookiesLink.addEventListener("click", (e) => {
         e.preventDefault();
         CookieSettings.open();
       });
+      this.cookiesLink.dataset.cookieTriggerBound = "true";
     }
   }
 
@@ -504,10 +505,23 @@ class FooterLoader {
     });
   }
   setupCookieButton() {
-    const cookieBtn = document.querySelector(".footer-cookie-btn");
-    if (cookieBtn) {
-      cookieBtn.addEventListener("click", () => CookieSettings.open());
-    }
+    const triggers = document.querySelectorAll("[data-cookie-trigger]");
+    if (!triggers.length) return;
+    triggers.forEach((trigger) => {
+      if (trigger.dataset.cookieTriggerBound) return;
+      const handler = (event) => {
+        const tag = trigger.tagName.toLowerCase();
+        if (tag === "a") {
+          const href = trigger.getAttribute("href") || "";
+          if (!href || href.startsWith("#")) {
+            event.preventDefault();
+          }
+        }
+        CookieSettings.open();
+      };
+      trigger.addEventListener("click", handler);
+      trigger.dataset.cookieTriggerBound = "true";
+    });
   }
   setupSmoothScroll() {
     const footer = document.getElementById("site-footer");

--- a/content/webentwicklung/footer/footer.html
+++ b/content/webentwicklung/footer/footer.html
@@ -23,7 +23,15 @@
       
       <!-- Navigation -->
       <nav class="footer-minimal-nav" aria-label="Footer links">
-  <button id="footer-cookies-link" type="button" class="footer-nav-link footer-cookies-link" aria-label="Cookie-Einstellungen" aria-controls="footer-cookie-view" aria-expanded="false">
+        <button
+          id="footer-cookies-link"
+          type="button"
+          class="footer-nav-link footer-cookies-link"
+          aria-label="Cookie-Einstellungen"
+          aria-controls="footer-cookie-view"
+          aria-expanded="false"
+          data-cookie-trigger
+        >
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="10"></circle>
             <circle cx="8" cy="10" r="1.5" fill="currentColor"></circle>
@@ -285,7 +293,14 @@
                   </svg>
                   Privacy
                 </a>
-                <button id="footer-open-cookie-btn" type="button" class="footer-cookie-btn" aria-label="Cookie-Einstellungen öffnen" aria-controls="footer-cookie-view" aria-expanded="false">
+                <button
+                  type="button"
+                  class="footer-cookie-btn"
+                  aria-label="Cookie-Einstellungen öffnen"
+                  aria-controls="footer-cookie-view"
+                  aria-expanded="false"
+                  data-cookie-trigger
+                >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
                     <path d="M21.95 10.99c-1.79-.03-3.7-1.95-2.68-4.22-2.97 1-5.78-1.59-5.19-4.56C7.11.02 2 6.27 2 12c0 5.52 4.48 10 10 10 5.89 0 10.54-5.08 9.95-11.01z" fill="currentColor"/>
                   </svg>

--- a/pages/about/about.css
+++ b/pages/about/about.css
@@ -178,6 +178,13 @@
    - Rücksicht auf Safe-Area Inset unten
 --------------------------------------------------------------------------- */
 @media (max-width: 600px) {
+  .about {
+    min-height: auto;
+    padding: 1.5rem 0;
+    justify-content: flex-start;
+    align-items: stretch;
+  }
+
   .about__container {
     padding: 2.5rem 1rem;
     font-size: 1rem; /* etwas kleiner als Desktop */

--- a/pages/about/about.css
+++ b/pages/about/about.css
@@ -170,6 +170,21 @@
   justify-content: flex-start;
 }
 
+.about-no-viewport .about__cta {
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.about-no-viewport .about__cta .btn {
+  width: 100%;
+  max-width: 100%;
+  padding: 0.9rem 1rem;
+  min-height: 44px;
+  min-width: 0;
+  text-align: center;
+}
+
 /* --------------------------------------------------------------------------
    Mobile-Optimierungen für die About-Sektion
    - kompakteres Padding

--- a/pages/about/about.html
+++ b/pages/about/about.html
@@ -8,68 +8,97 @@
     damit Screenreader das Icon beschreiben können.
 -->
 <section id="about" class="about">
+  <style data-inline="about-fallback">
+    .about__cta {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+    }
+
+    @media (max-width: 600px) {
+      .about__cta {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
+      }
+
+      .about__cta .btn {
+        width: 100%;
+        max-width: 100%;
+        text-align: center;
+      }
+    }
+  </style>
   <div class="about__container">
     <div class="about__content">
       <div class="about__text parallax-element" data-parallax-speed="0.1">
         <h1>Danke für Ihren Besuch!</h1>
 
-      <p>
-        Es freut mich sehr, dass Sie sich die Zeit genommen haben, meine Website
-        zu erkunden. Mein Name ist <strong>Abdulkerim</strong> und ich bin ein
-        leidenschaftlicher Webentwickler aus Berlin, der es liebt, digitale
-        Träume in die Realität umzusetzen.
-      </p>
+        <p>
+          Es freut mich sehr, dass Sie sich die Zeit genommen haben, meine
+          Website zu erkunden. Mein Name ist <strong>Abdulkerim</strong> und ich
+          bin ein leidenschaftlicher Webentwickler aus Berlin, der es liebt,
+          digitale Träume in die Realität umzusetzen.
+        </p>
 
-      <p>
-        Hinter jedem Projekt steckt eine Geschichte, hinter jedem Code eine
-        Vision. Ich glaube fest daran, dass großartige Websites mehr sind als
-        nur funktionale Tools – sie sind digitale Erlebnisse, die Menschen
-        bewegen und inspirieren.
-      </p>
+        <p>
+          Hinter jedem Projekt steckt eine Geschichte, hinter jedem Code eine
+          Vision. Ich glaube fest daran, dass großartige Websites mehr sind als
+          nur funktionale Tools – sie sind digitale Erlebnisse, die Menschen
+          bewegen und inspirieren.
+        </p>
 
-      <p>
-        Meine Mission ist es, das Web zu einem schöneren und zugänglicheren Ort
-        zu machen. Dabei verbinde ich moderne Technologien mit kreativem Design
-        und stelle den Menschen stets in den Mittelpunkt meiner Arbeit.
-      </p>
+        <p>
+          Meine Mission ist es, das Web zu einem schöneren und zugänglicheren
+          Ort zu machen. Dabei verbinde ich moderne Technologien mit kreativem
+          Design und stelle den Menschen stets in den Mittelpunkt meiner Arbeit.
+        </p>
 
-      <p>
-        <em>Jede Zeile Code, die ich schreibe, trägt ein Stück meiner Leidenschaft in sich.</em><br />
-        Von der ersten Idee bis zum finalen Launch begleite ich Sie auf Ihrer
-        digitalen Reise.
-      </p>
+        <p>
+          <em
+            >Jede Zeile Code, die ich schreibe, trägt ein Stück meiner
+            Leidenschaft in sich.</em
+          ><br />
+          Von der ersten Idee bis zum finalen Launch begleite ich Sie auf Ihrer
+          digitalen Reise.
+        </p>
 
-      <p>
-        Ich hoffe, meine Arbeit konnte Sie inspirieren und Ihnen einen Einblick
-        in meine Welt der Webentwicklung geben. Es war mir eine wahre Freude,
-        Sie hier zu haben.
-      </p>
+        <p>
+          Ich hoffe, meine Arbeit konnte Sie inspirieren und Ihnen einen
+          Einblick in meine Welt der Webentwicklung geben. Es war mir eine wahre
+          Freude, Sie hier zu haben.
+        </p>
 
-      <p class="about__farewell">
-        <strong>Herzlichen Dank für Ihr Interesse und besuchen Sie mich gerne wieder!</strong>
-      </p>
-
-      <div class="about__cta">
-        <a href="#hero" class="btn btn-primary">Zur Startseite</a>
-        <a href="#contact" class="btn btn-secondary">
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            aria-hidden="true"
-            focusable="false"
+        <p class="about__farewell">
+          <strong
+            >Herzlichen Dank für Ihr Interesse und besuchen Sie mich gerne
+            wieder!</strong
           >
-            <title>Lebenslauf herunterladen</title>
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-            <polyline points="7 10 12 15 17 10" />
-            <line x1="12" y1="15" x2="12" y2="3" />
-          </svg>
-          <span>Lebenslauf</span>
-        </a>
+        </p>
+
+        <div class="about__cta">
+          <a href="#hero" class="btn btn-primary">Zur Startseite</a>
+          <a href="#contact" class="btn btn-secondary">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <title>Lebenslauf herunterladen</title>
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            <span>Lebenslauf</span>
+          </a>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/pages/about/about.html
+++ b/pages/about/about.html
@@ -8,12 +8,40 @@
     damit Screenreader das Icon beschreiben können.
 -->
 <section id="about" class="about">
+  <script data-inline="about-viewport">
+    (function () {
+      if (typeof document === "undefined") return;
+      const viewportMeta = document.querySelector('meta[name="viewport"]');
+      if (!viewportMeta) {
+        document.documentElement.classList.add("about-no-viewport");
+        const meta = document.createElement("meta");
+        meta.name = "viewport";
+        meta.content = "width=device-width, initial-scale=1";
+        (document.head || document.documentElement).appendChild(meta);
+        if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+          window.dispatchEvent(new Event("resize"));
+        }
+      }
+    })();
+  </script>
   <style data-inline="about-fallback">
     .about__cta {
       display: flex;
       gap: 1rem;
       flex-wrap: wrap;
       justify-content: flex-start;
+    }
+
+    .about-no-viewport .about__cta {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.75rem;
+    }
+
+    .about-no-viewport .about__cta .btn {
+      width: 100%;
+      max-width: 100%;
+      text-align: center;
     }
 
     @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- inline a responsive fallback style in the about fragment so the CTA stack vertically on small viewports even when the page is loaded standalone
- drop the duplicate cookie trigger id, switch triggers to a shared data attribute, and centralize aria-expanded updates
- normalize the about section markup so tags are properly nested for section loading

## Testing
- npx playwright test tests/layout.spec.js *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_6909a9ba5ce88327bf4cbad628d5c7a1