### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/content/components/head/head-complete.js
+++ b/content/components/head/head-complete.js
@@ -13,6 +13,16 @@
     const existingTitleEl = document.querySelector('title')
     const pageTitle = existingTitleEl ? existingTitleEl.textContent : document.title || 'Abdulkerim — Digital Creator Portfolio'
 
+    const escapeHTML = value =>
+      String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+
+    const safePageTitle = escapeHTML(pageTitle)
+
     // 2. Shared Head laden (mit Caching für Performance)
     const resp = await fetch('/content/components/head/head.html', {cache: 'force-cache'})
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
@@ -20,7 +30,7 @@
     let html = await resp.text()
 
     // 3. Platzhalter {{PAGE_TITLE}} ersetzen
-    html = html.replace(/\{\{PAGE_TITLE}}/g, pageTitle)
+    html = html.replace(/\{\{PAGE_TITLE}}/g, safePageTitle)
 
     // 4. HTML in DOM-Knoten umwandeln
     const range = document.createRange()


### PR DESCRIPTION
Potential fix for [https://github.com/aKs030/iweb/security/code-scanning/1](https://github.com/aKs030/iweb/security/code-scanning/1)

In general, you must ensure that any untrusted text taken from the DOM is *contextually escaped* before injecting it into HTML that will be parsed. Here, `pageTitle` (derived from `existingTitleEl.textContent`) is directly substituted into the `html` template and then parsed as HTML. To preserve behavior while fixing the issue, we should HTML‑encode `pageTitle` before calling `replace`, so that any HTML metacharacters (`&`, `<`, `>`, `"`, `'`) are rendered harmless, but the visible text remains the same.

The best fix, with minimal behavior change, is:

1. Introduce a small helper `escapeHTML` near the top of the function to encode characters: `&`, `<`, `>`, `"`, `'`.
2. Convert `pageTitle` to a string and pass it through `escapeHTML` to produce `safePageTitle`.
3. Use `safePageTitle` instead of `pageTitle` in the `html.replace(/\{\{PAGE_TITLE}}/g, ...)` call.

This keeps the head-loading logic intact but ensures that even if the original `<title>` was influenced by user input, it cannot inject HTML/JS when the shared head is parsed. All changes are confined to `content/components/head/head-complete.js` in the shown region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
