### PR TITLE
Refactor: modularize legacy globals and add clean-mode (LEGACY_CLEAN_MODE)

### DIFF
--- a/content/components/head/head-complete.js
+++ b/content/components/head/head-complete.js
@@ -110,7 +110,7 @@
   // --- 2. HTML HEAD UPDATES (lightweight, no heavy DOM replacement) ---
   try {
     const {createLogger} = await import('../../utils/shared-utilities.js')
-    const log = createLogger('HeadLoader')
+    const _log = createLogger('HeadLoader')
 
     const _escapeHTML = str =>
       String(str).replace(/[&<>"']/g, m => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[m])

--- a/content/components/particles/three-earth-system.js
+++ b/content/components/particles/three-earth-system.js
@@ -4,7 +4,7 @@
  * @version 11.0.0 - REFACTOR: Pure WebGL Implementation
  */
 
-import {createLogger, getElementById, onResize, TimerManager} from '../../utils/shared-utilities.js'
+import {createLogger, getElementById, onResize, TimerManager, AppLoadManager} from '../../utils/shared-utilities.js'
 import {
   getSharedState,
   loadThreeJS,

--- a/content/components/typewriter/TypeWriter.js
+++ b/content/components/typewriter/TypeWriter.js
@@ -1,7 +1,8 @@
 // ===== TypeWriter (Final Optimiert) =====
-import {createLogger, getElementById, shuffle, TimerManager} from '../../utils/shared-utilities.js'
+import {createLogger, getElementById, shuffle, TimerManager, setLegacyGlobal} from '../../utils/shared-utilities.js'
 
 const log = createLogger('TypeWriter')
+export let typeWriterInstance = null
 
 // Helper: CSS Variables setzen
 const setCSSVars = (el, vars) => Object.entries(vars).forEach(([k, v]) => el.style.setProperty(k, v))
@@ -374,7 +375,14 @@ export async function initHeroSubtitle(options = {}) {
         passive: true
       })
 
-      if (window.location.search.includes('debug')) window.__typeWriter = tw
+      // Expose instance for imports (preferred) and keep debug window hook for quick manual debugging
+      typeWriterInstance = tw
+      // Expose instance for imports (preferred) and keep debug window hook only via helper (respects clean mode)
+      typeWriterInstance = tw
+      setLegacyGlobal('__typeWriter', tw, {
+        debugOnly: true,
+        note: 'Use import { typeWriterInstance } from "../../content/components/typewriter/TypeWriter.js" instead (window global is deprecated)'
+      })
     }
 
     ;(document.fonts?.ready ?? Promise.resolve()).then(start)

--- a/pages/home/hero-manager.js
+++ b/pages/home/hero-manager.js
@@ -1,6 +1,7 @@
 // ===== Shared Utilities Import =====
 import {createTriggerOnceObserver, EVENTS, getElementById, TimerManager} from '../../content/utils/shared-utilities.js'
 import {createLogger} from '../../content/utils/shared-utilities.js'
+import {initHeroSubtitle} from '../../content/components/typewriter/TypeWriter.js'
 
 // Logger für HeroManager
 const logger = createLogger('HeroManager')
@@ -14,16 +15,15 @@ const HeroManager = (() => {
   let isInitialized = false
 
   async function loadTyped(heroDataModule) {
-    // Optimized: Use global function exposed by main.js or imported directly
-    if (typeof window.initHeroSubtitle === 'function') {
-      try {
-        return window.initHeroSubtitle({
-          heroDataModule
-        })
-      } catch (err) {
-        logger.warn('Failed to load TypeWriter modules', err)
-        return false
+    try {
+      if (typeof initHeroSubtitle === 'function') {
+        return await initHeroSubtitle({heroDataModule})
+      } else if (typeof window.initHeroSubtitle === 'function') {
+        return await window.initHeroSubtitle({heroDataModule})
       }
+    } catch (err) {
+      logger.warn('Failed to load TypeWriter modules', err)
+      return false
     }
     return false
   }


### PR DESCRIPTION
This PR modularizes legacy global shims and introduces a controlled clean-mode to discourage use of window.* globals.

Key changes:
- Added `AppLoadManager` singleton and exported it from `shared-utilities.js`.
- Implemented `LEGACY_CLEAN_MODE` and `setLegacyGlobal` helper to control exposure of deprecated globals (use `?clean` or `window.__CLEAN_GLOBALS = true` to prevent shims).
- Exported debug hooks (`__threeEarthCleanup`, `__rws`, `__devRws`, `typeWriterInstance`) and replaced direct `window.*` writes with `setLegacyGlobal(...)` (debug-only where applicable).
- Updated `TypeWriter`, `main`, and `HeroManager` to use imports with fallbacks and added lint/format fixes.

Notes for reviewers:
- All changes are backwards compatible when `?debug` is present or `LEGACY_CLEAN_MODE` is disabled (default). Use `?clean` to opt-in to strict mode.
- Suggested follow-up: consider conservative migration of `window.THREE` and `window.dataLayer` in a separate PR.

Tests & checks:
- ESLint and Prettier checks run locally; Playwright run (no tests) and basic smoke server validation done.

Please review code, especially any inline scripts or third-party integrations that might rely on legacy globals.