### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node


### PR DESCRIPTION
Potential fix for [https://github.com/aKs030/iweb/security/code-scanning/4](https://github.com/aKs030/iweb/security/code-scanning/4)

In general, the problem is fixed by explicitly specifying a restrictive `permissions` block either at the workflow level (top-level, applying to all jobs) or at the individual job level. For this workflow, the job only needs to read repository contents to run tests, so `contents: read` is sufficient.

The best minimal fix without changing existing functionality is to add a `permissions` block to the `test` job. This keeps the change localized and ensures only that job’s token is restricted. Specifically, in `.github/workflows/playwright.yml`, under `jobs:`, inside the `test:` job definition and at the same indentation level as `runs-on:`, add:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are needed, since this is a YAML configuration change only. All existing steps (checkout, setup-node, npm ci, Playwright install, tests) will continue to work with read-only repository access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
