### PR TITLE
Refactor CSS media queries and remove duplicates

### DIFF
--- a/content/components/footer/footer.css
+++ b/content/components/footer/footer.css
@@ -902,7 +902,7 @@ body.footer-expanded {
 }
 
 /* ===== Responsive ===== */
-@media (max-width: 900px) {
+@media (width <= 900px) {
   .site-footer {
     width: calc(100% - 16px);
     bottom: 8px;
@@ -1135,7 +1135,7 @@ body.footer-expanded {
   }
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .footer-max {
     padding: 10px;
     max-height: calc(100vh - 80px);

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -214,7 +214,7 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .loader-content {
     width: 80%;
   }

--- a/content/styles/root.css
+++ b/content/styles/root.css
@@ -156,6 +156,7 @@
       --greet-fs: var(--headline-fs);
       --greet-min-inline: clamp(14ch, 36vw, 28ch);
       --greet-max: clamp(14ch, 100vw, 26ch);
+      --card-min-width: 0; /* allow cards to shrink on small devices */
     }
   }
 
@@ -305,13 +306,6 @@ iframe {
   max-width: 100%;
   height: auto;
   display: block;
-}
-
-/* Mobile: allow cards to shrink */
-@media (width <= 420px) {
-  :root {
-    --card-min-width: 0; /* allow cards to shrink on small devices */
-  }
 }
 
 /* =======================

--- a/pages/blog/blog.css
+++ b/pages/blog/blog.css
@@ -207,7 +207,7 @@ body {
   gap: 2.5rem;
 }
 
-@media (max-width: 640px) {
+@media (width <= 640px) {
   .blog-grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
Updated CSS media queries to use modern Level 4 Range Context syntax (`width <= X`) across `main.css`, `footer.css`, and `blog.css`. Removed a duplicate `@media (width <= 420px)` block in `root.css` by merging content. Verified changes with build check and frontend screenshots.

---
*PR created automatically by Jules for task [11598373020804614754](https://jules.google.com/task/11598373020804614754) started by @aKs030*