### PR TITLE
Update CSP to allow inline scripts for Cloudflare compatibility

### DIFF
--- a/_headers
+++ b/_headers
@@ -35,16 +35,17 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=()
   
   # Content Security Policy - ENFORCEMENT MODE (Phase 3) ✅
-  # Strict CSP (unsafe-inline allowed for styles)
+  # Strict CSP (unsafe-inline allowed for styles and scripts)
   # 
   # Changes from Report-Only:
   # - Allowed 'unsafe-inline' for style-src (required for animations/JS styling)
+  # - Allowed 'unsafe-inline' for script-src (required for Cloudflare Challenge/Bot Fight Mode)
   # - Added Gemini API to connect-src
   # - Switched to enforcement mode (blocks violations)
   #
   # CSP Directives:
   # - default-src 'self': Only allow resources from same origin by default
-  # - script-src: Allow scripts from self, external CDNs (jsDelivr), Google services
+  # - script-src: Allow scripts from self, external CDNs (jsDelivr), Google services, and inline (for Cloudflare)
   # - style-src: Allow styles from self, Google Fonts, and inline styles
   # - img-src: Allow images from self, YouTube, Google Analytics, data URIs, blobs
   # - font-src: Allow fonts from self and Google Fonts
@@ -58,4 +59,4 @@
   #
   # Note: JSON-LD scripts are safe (type="application/ld+json" is not executable)
   # Note: Module scripts with src are allowed (type="module" with external src)
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://i.ytimg.com https://i9.ytimg.com https://www.youtube.com https://www.google-analytics.com https://www.abdulkerimsesli.de data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.googleapis.com https://www.google-analytics.com https://generativelanguage.googleapis.com https://raw.githack.com https://cdn.jsdelivr.net https://raw.githubusercontent.com; frame-src https://www.youtube-nocookie.com https://www.abdulkerimsesli.de https://raw.githack.com https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.googletagmanager.com https://www.google-analytics.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://i.ytimg.com https://i9.ytimg.com https://www.youtube.com https://www.google-analytics.com https://www.abdulkerimsesli.de data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.googleapis.com https://www.google-analytics.com https://generativelanguage.googleapis.com https://raw.githack.com https://cdn.jsdelivr.net https://raw.githubusercontent.com; frame-src https://www.youtube-nocookie.com https://www.abdulkerimsesli.de https://raw.githack.com https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests


### PR DESCRIPTION
Updated the Content Security Policy in `_headers` to allow inline scripts, resolving errors caused by Cloudflare's injected challenge scripts.

---
*PR created automatically by Jules for task [10336755088587020662](https://jules.google.com/task/10336755088587020662) started by @aKs030*