### PR TITLE
Refactor Components to Shadow DOM

### DIFF
--- a/content/components/footer/footer-css.js
+++ b/content/components/footer/footer-css.js
@@ -1,17 +1,17 @@
-/**
+export default `/**
  * Modern Footer System v10.0 - Final
  * Minimalistisches Design konsistent mit Menüleiste
  * @author Abdulkerim Sesli
  */
 
 /* ===== CSS Variables ===== */
-:root {
+:host {
   --footer-transition: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   --footer-spring: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 
 /* ===== Base Footer ===== */
-.site-footer {
+:host {
   position: fixed;
   bottom: 12px;
   left: 50%;
@@ -39,6 +39,8 @@
   letter-spacing: -0.02em;
   animation: footerAppear 0.8s var(--footer-spring) forwards;
   opacity: 0;
+  display: block;
+  box-sizing: border-box;
 }
 
 @keyframes footerAppear {
@@ -888,21 +890,19 @@
 }
 
 /* ===== Expanded State ===== */
-.site-footer.expanded .footer-min {
+:host(.expanded) .footer-min {
   display: none;
 }
 
-.site-footer.expanded .footer-max {
+:host(.expanded) .footer-max {
   display: flex;
 }
 
-body.footer-expanded {
-  padding-bottom: calc(80vh + 24px);
-}
+/* Removed body.footer-expanded, handled via JS */
 
 /* ===== Responsive ===== */
 @media (width <= 900px) {
-  .site-footer {
+  :host {
     width: calc(100% - 16px);
     bottom: 8px;
     border-radius: 20px;
@@ -1332,13 +1332,13 @@ body.footer-expanded {
 }
 
 @media (prefers-contrast: more) {
-  .site-footer {
+  :host {
     border-width: 2px;
   }
 }
 
 @media print {
-  .site-footer {
+  :host {
     display: none;
   }
 }
@@ -1359,3 +1359,4 @@ body.footer-expanded {
 .year::after {
   content: attr(data-year);
 }
+`;

--- a/content/components/head/head-inline.js
+++ b/content/components/head/head-inline.js
@@ -163,20 +163,21 @@ dataLayer.push({
       // Ensure <site-menu> exists
       let siteMenu = document.querySelector('site-menu');
       if (!siteMenu) {
-        let headerEl = document.querySelector('header.site-header');
-        if (!headerEl) {
-          headerEl = document.createElement('header');
-          headerEl.className = 'site-header';
-          document.body.insertBefore(headerEl, document.body.firstChild);
-        }
+        // Remove old wrappers if present to ensure clean state
+        const oldHeader = document.querySelector('header.site-header');
+        if (oldHeader) oldHeader.remove();
 
-        // Remove old container if present
         const oldContainer = document.getElementById('menu-container');
         if (oldContainer) oldContainer.remove();
 
         siteMenu = document.createElement('site-menu');
         siteMenu.dataset.injectedBy = 'head-inline';
-        headerEl.appendChild(siteMenu);
+        // Insert as first child of body
+        if (document.body.firstChild) {
+          document.body.insertBefore(siteMenu, document.body.firstChild);
+        } else {
+          document.body.appendChild(siteMenu);
+        }
       }
 
       // Ensure <site-footer> exists
@@ -242,7 +243,7 @@ dataLayer.push({
 
     const SCRIPTS = [
       { src: '/content/main.js', module: true, preload: false },
-      { src: '/content/components/menu/menu.js', module: true },
+      { src: '/content/components/menu/SiteMenu.js', module: true },
     ];
 
     const deferNonCriticalAssets = () => {

--- a/content/components/menu/menu-css.js
+++ b/content/components/menu/menu-css.js
@@ -1,4 +1,4 @@
-/**
+export default `/**
  * Modern Menu System - Styles
  * 
  * Features:
@@ -123,8 +123,8 @@
   font-weight: 510;
 }
 
-/* ===== Header ===== */
-.site-header {
+/* ===== Host (Header) ===== */
+:host {
   position: fixed;
   top: 12px;
   left: 50%;
@@ -158,6 +158,7 @@
   );
   font-weight: 500;
   letter-spacing: -0.02em;
+  box-sizing: border-box;
 }
 
 @keyframes headerAppear {
@@ -514,10 +515,15 @@
 }
 
 /* ===== Page Layout ===== */
-main {
+/* Note: Main layout adjustment should be global, but for encapsulation we might want to push content? */
+/* However, this selector targets 'main' which is outside shadow dom. It won't work in Shadow DOM. */
+/* I will leave it commented out or remove it, as main margin should be handled by main css or host context. */
+/* But 'menu.css' had it. If I remove it, the content might hide behind the fixed header. */
+/* For now, I'll rely on global styles for the main top margin. */
+/* main {
   margin-top: 88px;
   padding: 1rem;
-}
+} */
 
 /* ===== Active Link States ===== */
 .site-menu__list li a.active,
@@ -530,7 +536,7 @@ main {
 
 /* ===== Mobile Responsive ===== */
 @media (width <= 900px) {
-  .site-header {
+  :host {
     display: flex;
     justify-content: flex-start;
     top: 8px;
@@ -560,9 +566,9 @@ main {
     transform: translateY(-50%);
   }
 
-  main {
+  /* main {
     margin-top: 72px;
-  }
+  } */
 
   /* Mobile Menu Card */
   .site-menu {
@@ -636,3 +642,4 @@ main {
     min-height: 20px;
   }
 }
+`;

--- a/content/components/menu/menu.js
+++ b/content/components/menu/menu.js
@@ -1,5 +1,0 @@
-/**
- * Modern Menu System Entry Point
- * Imports the Web Component definition.
- */
-import './SiteMenu.js';

--- a/content/components/particles/three-earth-system.js
+++ b/content/components/particles/three-earth-system.js
@@ -989,7 +989,7 @@ export {
   // _detectAndEnsureWebGL is internal now
 };
 // Re-export specific helpers if needed by tests, but ideally tests should use the class instance or mocks
-// eslint-disable-next-line no-unused-vars
+
 export const _createLoadingManager = (_T, c) => { if(singleton) return singleton._createLoadingManager(c); return null; };
 export const _detectAndEnsureWebGL = (c) => { if(singleton) return singleton._detectAndEnsureWebGL(c); return true; };
 

--- a/content/main.js
+++ b/content/main.js
@@ -12,7 +12,7 @@ import { SectionManager } from './core/section-manager.js';
 import { LoaderManager } from './core/loader-manager.js';
 import { ThreeEarthManager } from './core/three-earth-manager.js';
 import { getElementById, onDOMReady } from './core/dom-utils.js';
-import './components/menu/menu.js';
+import './components/menu/SiteMenu.js';
 import './components/footer/SiteFooter.js';
 
 const log = createLogger('main');

--- a/vite-plugin-redirects.js
+++ b/vite-plugin-redirects.js
@@ -21,6 +21,13 @@ export function htmlRawPlugin() {
 
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
+        // Skip if it's a ?raw import request - let Vite handle it
+        if (req.url.includes('?raw')) {
+          console.log(`[htmlRawPlugin] Skipping ?raw request: ${req.url}`);
+          next();
+          return;
+        }
+
         const url = req.url.split('?')[0];
 
         // Skip entry point HTML files - let Vite handle them
@@ -29,8 +36,10 @@ export function htmlRawPlugin() {
           return;
         }
 
-        // Serve other HTML files from pages/ and content/components/ as raw HTML
-        if (url.match(/\/(pages|content\/components)\/.*\.html$/)) {
+        // Serve other HTML files from pages/ as raw HTML
+        // content/components are now bundled via ?raw import, so let Vite handle them
+        if (url.match(/\/pages\/.*\.html$/)) {
+          console.log(`[htmlRawPlugin] Intercepting HTML: ${url}`);
           try {
             const filePath = resolve(process.cwd(), url.substring(1));
             const content = readFileSync(filePath, 'utf-8');


### PR DESCRIPTION
Converted `SiteFooter` and `SiteMenu` to use Shadow DOM for encapsulation. 
- Implemented `attachShadow({ mode: 'open' })` in both components.
- Updated `SiteMenu` to inject global layout styles (`main` margin) dynamically to prevent layout shifts.
- Replaced `header.site-header` wrapper in `head-inline.js` with direct injection of `<site-menu>`.
- Updated CSS to use `:host` selectors.
- Converted component CSS to JS string modules (`menu-css.js`, `footer-css.js`) to work around Vite build issues with `?raw` CSS imports in this environment.
- Removed obsolete `menu.js` wrapper and original CSS files.
- Updated `MenuEvents`, `MenuRenderer`, `MenuAccessibility` to handle Shadow DOM retargeting and scoping.

---
*PR created automatically by Jules for task [15014050761937935702](https://jules.google.com/task/15014050761937935702) started by @aKs030*