### PR TITLE
Fix loading screen hang on initialization timeout

### DIFF
--- a/content/core/three-earth-manager.js
+++ b/content/core/three-earth-manager.js
@@ -49,9 +49,8 @@ export class ThreeEarthManager {
 
       // Timeout wrapper for initialization
       const loadPromise = async () => {
-        const { initThreeEarth } = await import(
-          '../components/particles/three-earth-system.js'
-        );
+        const { initThreeEarth } =
+          await import('../components/particles/three-earth-system.js');
 
         if (typeof initThreeEarth !== 'function') {
           throw new Error('initThreeEarth not found in module exports');

--- a/content/main.js
+++ b/content/main.js
@@ -363,10 +363,10 @@ document.addEventListener(
 
     // Force hide after timeout
     setTimeout(() => {
-      if (!windowLoaded) {
-        log.info('Forcing loading screen hide after timeout');
-        LoadingScreenManager.hide();
-      }
+      // Force hide if still visible, regardless of windowLoaded state
+      // This prevents hanging if Three.js fails or assets don't load
+      log.info('Forcing loading screen hide after timeout');
+      LoadingScreenManager.hide();
     }, LOADING_TIMEOUT_MS);
 
     schedulePersistentStorageRequest(STORAGE_REQUEST_DELAY_MS);


### PR DESCRIPTION
Fixed an issue where the application would get stuck on the loading screen if the `window` load event fired but the 3D Earth system failed to initialize or took too long. The fallback timeout in `content/main.js` was previously only triggering if `windowLoaded` was false. It now triggers unconditionally after 4000ms to ensure the user can always access the site content.

---
*PR created automatically by Jules for task [9166247500037428896](https://jules.google.com/task/9166247500037428896) started by @aKs030*