### PR TITLE
Fix: Enable edge-to-edge layout with safe-area support

### DIFF
--- a/content/components/footer/footer.css
+++ b/content/components/footer/footer.css
@@ -12,7 +12,7 @@ address {
 /* ===== Base Footer ===== */
 .site-footer {
   position: fixed;
-  bottom: 12px;
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   left: 50%;
   transform: translateX(-50%);
   width: calc(100% - 32px);
@@ -918,7 +918,7 @@ body.footer-expanded {
 @media (width <= 900px) {
   .site-footer {
     width: calc(100% - 16px);
-    bottom: 8px;
+    bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     border-radius: 20px;
     min-width: auto;
   }

--- a/content/components/menu/menu.css
+++ b/content/components/menu/menu.css
@@ -126,7 +126,7 @@
 /* ===== Header ===== */
 .site-header {
   position: fixed;
-  top: 12px;
+  top: calc(12px + env(safe-area-inset-top, 0px));
   left: 50%;
   width: calc(100% - 32px);
   max-width: 1440px;
@@ -739,7 +739,7 @@ main {
   .site-header {
     display: flex;
     justify-content: flex-start;
-    top: 8px;
+    top: calc(8px + env(safe-area-inset-top, 0px));
     width: calc(100% - 16px);
     height: 48px;
     padding: 0 20px;
@@ -773,7 +773,7 @@ main {
   /* Mobile Menu Card */
   .site-menu {
     position: fixed;
-    top: 64px;
+    top: calc(64px + env(safe-area-inset-top, 0px));
     right: 8px;
     width: min(90vw, 320px);
     padding: 0;

--- a/content/styles/variables.css
+++ b/content/styles/variables.css
@@ -46,6 +46,8 @@
   --pad-x: max(1rem, env(safe-area-inset-left));
   --pad-y: 1rem;
 
+  --header-height: 64px;
+
   /* ========================================
      BORDERS & RADIUS
      ======================================== */
@@ -160,4 +162,10 @@
   --section3-leading-lg: 1.5;
   --section3-leading-md: 1.4;
   --section3-leading-sm: 1.3;
+}
+
+@media (width <= 900px) {
+  :root {
+    --header-height: 56px;
+  }
 }


### PR DESCRIPTION
- Defined `--header-height` in `variables.css` to ensure consistent content padding.
- Updated `.site-header` and `.site-menu` in `menu.css` to respect `env(safe-area-inset-top)`, preventing overlap with the device notch/status bar.
- Updated `.site-footer` in `footer.css` to respect `env(safe-area-inset-bottom)`, preventing overlap with the home indicator.
- These changes enable a correct "immersive" mode where the background covers the full screen while UI elements remain in the safe area.

---
*PR created automatically by Jules for task [15560330045901283737](https://jules.google.com/task/15560330045901283737) started by @aKs030*