### PR TITLE
Refactor SiteFooter to use scroll chaining logic

### DIFF
--- a/content/components/footer/SiteFooter.js
+++ b/content/components/footer/SiteFooter.js
@@ -129,6 +129,7 @@ export class SiteFooter extends HTMLElement {
     this.initialized = false;
     this.isTransitioning = false;
     this.touchStartY = 0;
+    this.lastScrollY = 0;
 
     /** @type {FooterElements} */
     this.elements = {
@@ -288,7 +289,7 @@ export class SiteFooter extends HTMLElement {
 
   setupScrollChaining() {
     // Add wheel listener for desktop
-    window.addEventListener('wheel', this.handleWheel, { passive: false });
+    window.addEventListener('wheel', this.handleWheel, { passive: true });
 
     // Touch listeners are added in setupGlobalEventListeners
   }
@@ -307,7 +308,7 @@ export class SiteFooter extends HTMLElement {
       passive: true,
     });
     window.addEventListener('touchmove', this.handleTouchMove, {
-      passive: false, // passive: false needed to potentially prevent default if we want to lock scroll
+      passive: true,
     });
 
     window.addEventListener('resize', this.handleResize, { passive: true });

--- a/content/components/footer/SiteFooter.js
+++ b/content/components/footer/SiteFooter.js
@@ -129,7 +129,6 @@ export class SiteFooter extends HTMLElement {
     this.initialized = false;
     this.isTransitioning = false;
     this.touchStartY = 0;
-    this.lastScrollY = 0;
 
     /** @type {FooterElements} */
     this.elements = {

--- a/content/components/particles/three-earth-system.js
+++ b/content/components/particles/three-earth-system.js
@@ -858,7 +858,7 @@ class ThreeEarthSystem {
 
   _setupSectionDetection() {
     const sections = Array.from(
-      document.querySelectorAll('section[id], div#footer-trigger-zone'),
+      document.querySelectorAll('section[id], #site-footer'),
     );
     if (!sections.length || !('IntersectionObserver' in window)) return;
 
@@ -1264,7 +1264,7 @@ function getOptimizedConfig(capabilities) {
  * @param {string} id
  */
 function _mapId(id) {
-  return id === 'footer-trigger-zone' ? 'site-footer' : id;
+  return id;
 }
 
 /**

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -596,15 +596,6 @@ a:hover {
   color: white;
 }
 
-.footer-trigger-zone {
-  display: block;
-  width: 100%;
-  height: 1px;
-  pointer-events: none;
-  visibility: hidden;
-  position: relative;
-}
-
 /* ===== END GLOBAL COMPONENTS ===== */
 
 /* ===== RESPONSIVE: MOBILE & TABLET ===== */


### PR DESCRIPTION
Replaced legacy IntersectionObserver footer trigger with a robust scroll chaining mechanism. The footer now expands automatically when scrolling past the bottom of the page and collapses when scrolling up from the top of the footer content. This change applies globally and removes old section-specific triggers.

---
*PR created automatically by Jules for task [13854150440359135198](https://jules.google.com/task/13854150440359135198) started by @aKs030*