### PR TITLE
Add animated Cyber-Grid background to 3D Earth system

### DIFF
--- a/content/components/particles/earth/config.js
+++ b/content/components/particles/earth/config.js
@@ -110,6 +110,18 @@ export const CONFIG = {
     SHOWER_COOLDOWN: 1200,
     MAX_SIMULTANEOUS: 3,
   },
+  GRID: {
+    ENABLED: true,
+    COLOR: 0x00f3ff, // Cyan
+    OPACITY: 0.12, // Subtle
+    SIZE: 200, // Large coverage
+    DIVISIONS: 40, // Grid density
+    SPEED: 0.2, // Slow scroll
+    FOG_NEAR: 10, // Start fading out
+    FOG_FAR: 80, // Fully transparent
+    Y_POS: -10, // Below the earth
+    FADE_SPEED: 0.05, // Opacity transition speed
+  },
   PERFORMANCE: {
     PIXEL_RATIO: Math.min(window.devicePixelRatio || 1, 1.5),
     TARGET_FPS: 30,

--- a/content/components/particles/earth/grid.js
+++ b/content/components/particles/earth/grid.js
@@ -1,0 +1,147 @@
+import { CONFIG } from './config.js';
+import { createLogger } from '/content/core/logger.js';
+
+const log = createLogger('EarthGrid');
+
+export class GridManager {
+  constructor(THREE, scene) {
+    this.THREE = THREE;
+    this.scene = scene;
+    this.mesh = null;
+    this.active = false;
+    this.opacity = 0;
+    this.targetOpacity = 0;
+  }
+
+  init() {
+    if (!CONFIG.GRID.ENABLED) return;
+
+    try {
+      // Create a large plane
+      const geometry = new this.THREE.PlaneGeometry(
+        CONFIG.GRID.SIZE,
+        CONFIG.GRID.SIZE,
+        1,
+        1,
+      );
+
+      // Custom shader for the cyber-grid effect
+      const material = new this.THREE.ShaderMaterial({
+        transparent: true,
+        side: this.THREE.DoubleSide,
+        depthWrite: false, // Don't block stars/earth behind it (though it's usually below)
+        blending: this.THREE.AdditiveBlending, // Glowing effect
+        uniforms: {
+          uTime: { value: 0 },
+          uColor: { value: new this.THREE.Color(CONFIG.GRID.COLOR) },
+          uOpacity: { value: 0 }, // Master opacity
+          uGridSize: { value: CONFIG.GRID.DIVISIONS },
+          uSpeed: { value: CONFIG.GRID.SPEED },
+          uFogNear: { value: CONFIG.GRID.FOG_NEAR },
+          uFogFar: { value: CONFIG.GRID.FOG_FAR },
+        },
+        vertexShader: `
+          varying vec2 vUv;
+          varying float vDistance;
+
+          void main() {
+            vUv = uv;
+            vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+            vec4 viewPosition = viewMatrix * worldPosition;
+            vDistance = -viewPosition.z; // Distance from camera
+            gl_Position = projectionMatrix * viewPosition;
+          }
+        `,
+        fragmentShader: `
+          uniform float uTime;
+          uniform vec3 uColor;
+          uniform float uOpacity;
+          uniform float uGridSize;
+          uniform float uSpeed;
+          uniform float uFogNear;
+          uniform float uFogFar;
+
+          varying vec2 vUv;
+          varying float vDistance;
+
+          void main() {
+            // Scrolling effect
+            vec2 pos = vUv * uGridSize;
+            pos.y += uTime * uSpeed;
+
+            // Grid lines
+            // Using smoothstep for anti-aliased lines
+            vec2 grid = abs(fract(pos - 0.5) - 0.5) / fwidth(pos);
+            float line = min(grid.x, grid.y);
+            float strength = 1.0 - min(line, 1.0);
+
+            // Distance fade (Fog)
+            float fogFactor = smoothstep(uFogFar, uFogNear, vDistance);
+
+            // Final alpha
+            float alpha = strength * uOpacity * fogFactor;
+
+            // Discard fully transparent pixels
+            if (alpha < 0.01) discard;
+
+            gl_FragColor = vec4(uColor, alpha);
+          }
+        `,
+      });
+
+      this.mesh = new this.THREE.Mesh(geometry, material);
+      this.mesh.rotation.x = -Math.PI / 2; // Lie flat
+      this.mesh.position.y = CONFIG.GRID.Y_POS;
+
+      this.scene.add(this.mesh);
+      this.active = true;
+      log.info('Cyber-Grid initialized');
+    } catch (err) {
+      log.error('Failed to init grid', err);
+    }
+  }
+
+  /**
+   * Update animation loop
+   * @param {number} time - Total elapsed time in seconds
+   * @param {number} delta - Time since last frame
+   */
+  update(time, delta) {
+    if (!this.active || !this.mesh) return;
+
+    // Update time uniform for scrolling
+    this.mesh.material.uniforms.uTime.value = time;
+
+    // Smooth opacity transition (Frame-rate independent)
+    if (Math.abs(this.opacity - this.targetOpacity) > 0.001) {
+      const factor = Math.min(delta * CONFIG.GRID.FADE_SPEED * 60, 1.0);
+      this.opacity += (this.targetOpacity - this.opacity) * factor;
+      this.mesh.material.uniforms.uOpacity.value = this.opacity;
+      this.mesh.visible = this.opacity > 0.001;
+    }
+  }
+
+  /**
+   * Fade grid in
+   */
+  show() {
+    this.targetOpacity = CONFIG.GRID.OPACITY;
+  }
+
+  /**
+   * Fade grid out
+   */
+  hide() {
+    this.targetOpacity = 0;
+  }
+
+  cleanup() {
+    if (this.mesh) {
+      this.scene.remove(this.mesh);
+      this.mesh.geometry.dispose();
+      this.mesh.material.dispose();
+      this.mesh = null;
+    }
+    this.active = false;
+  }
+}

--- a/content/components/particles/three-earth-system.js
+++ b/content/components/particles/three-earth-system.js
@@ -27,6 +27,7 @@ import {
 import { CameraManager } from './earth/camera.js';
 import { StarManager, ShootingStarManager } from './earth/stars.js';
 import { CardManager } from './earth/cards.js';
+import { GridManager } from './earth/grid.js';
 import {
   showLoadingState,
   hideLoadingState,
@@ -168,6 +169,7 @@ class ThreeEarthSystem {
     /** @type {ShootingStarManager|null} */ this.shootingStarManager = null;
     /** @type {PerformanceMonitor|null} */ this.performanceMonitor = null;
     /** @type {CardManager|null} */ this.cardManager = null;
+    /** @type {GridManager|null} */ this.gridManager = null;
 
     // State
     this.currentSection = 'hero';
@@ -307,6 +309,7 @@ class ThreeEarthSystem {
     this.shootingStarManager?.cleanup();
     this.cameraManager?.cleanup();
     this.starManager?.cleanup();
+    this.gridManager?.cleanup();
 
     // ✅ Explicit null assignment after disconnect
     if (this.sectionObserver) {
@@ -548,6 +551,9 @@ class ThreeEarthSystem {
 
     this.shootingStarManager = new ShootingStarManager(this.scene, this.THREE);
 
+    this.gridManager = new GridManager(this.THREE, this.scene);
+    this.gridManager.init();
+
     this.cardManager = new CardManager(
       this.THREE,
       this.scene,
@@ -777,6 +783,7 @@ class ThreeEarthSystem {
     }
 
     if (!capabilities.isLowEnd) this.shootingStarManager?.update(delta);
+    if (!capabilities.isLowEnd) this.gridManager?.update(totalTime, delta);
     this.performanceMonitor?.update();
 
     this._render();
@@ -892,6 +899,15 @@ class ThreeEarthSystem {
 
     const prev = this.currentSection;
     this.currentSection = newSection;
+
+    // Grid Visibility Logic
+    if (this.gridManager) {
+      if (newSection === 'hero') {
+        this.gridManager.hide();
+      } else {
+        this.gridManager.show();
+      }
+    }
 
     this.cameraManager?.updateCameraForSection(newSection);
 


### PR DESCRIPTION
Implemented a "Cyber-Grid" background effect for the 3D Earth system.

**Changes:**
1.  **`content/components/particles/earth/grid.js`**: New component. Uses `THREE.ShaderMaterial` to render a performant, anti-aliased grid that fades into the distance (fog) and scrolls over time. Includes logic for smooth opacity transitions.
2.  **`content/components/particles/three-earth-system.js`**: Integrated `GridManager`.
    *   Initializes the grid on startup.
    *   Updates the grid in the animation loop, passing `totalTime` and `delta`.
    *   Manages visibility in `_handleSectionChange`: The grid fades out when in the 'hero' section (to focus on the Earth) and fades in during other sections (e.g., 'features', 'about') to fill the background.
3.  **`content/components/particles/earth/config.js`**: Added `GRID` configuration block (Cyan color, opacity 0.12, scrolling speed 0.2).

**Technical Details:**
-   The grid shader uses `fwidth` for consistent line thickness and `smoothstep` for distance fog.
-   Animation logic uses `delta` time for consistent fade speeds regardless of frame rate.
-   Grid is positioned below the Earth (`Y_POS: -10`) to act as a floor/horizon.

---
*PR created automatically by Jules for task [7446502481229648950](https://jules.google.com/task/7446502481229648950) started by @aKs030*