### PR TITLE
Centralize and standardize Safe Area CSS variables

### DIFF
--- a/content/components/particles/earth/cards.js
+++ b/content/components/particles/earth/cards.js
@@ -158,13 +158,12 @@ export class CardManager {
 
             // Header offset - account for mobile safe areas
             const headerPixels = 20;
-            const safeAreaTop = isMobile
-              ? parseFloat(
-                  getComputedStyle(document.documentElement).getPropertyValue(
-                    '--safe-top',
-                  ),
-                ) || 0
-              : 0;
+            const safeAreaTop =
+              parseFloat(
+                getComputedStyle(document.documentElement).getPropertyValue(
+                  '--safe-top',
+                ),
+              ) || 0;
             const totalHeaderOffset = headerPixels + safeAreaTop;
             const headerWorldOffset = this._pixelsToWorldY(totalHeaderOffset);
 

--- a/content/components/particles/earth/cards.js
+++ b/content/components/particles/earth/cards.js
@@ -158,13 +158,13 @@ export class CardManager {
 
             // Header offset - account for mobile safe areas
             const headerPixels = 20;
-            const safeAreaTop =
-              isMobile &&
-              globalThis.window?.CSS?.supports?.(
-                'padding: env(safe-area-inset-top)',
-              )
-                ? 20
-                : 0; // Additional offset for notched devices
+            const safeAreaTop = isMobile
+              ? parseFloat(
+                  getComputedStyle(document.documentElement).getPropertyValue(
+                    '--safe-top',
+                  ),
+                ) || 0
+              : 0;
             const totalHeaderOffset = headerPixels + safeAreaTop;
             const headerWorldOffset = this._pixelsToWorldY(totalHeaderOffset);
 

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -612,11 +612,6 @@ a:hover {
 
 /* Tablet & Mobile: 768px and below */
 @media (width <= 768px) {
-  :root {
-    --menu-height: 64px; /* 48px + 8px top + 8px spacing */
-    --footer-height: 64px; /* 48px + 8px bottom + 8px spacing */
-  }
-
   html {
     font-size: 15px;
   }
@@ -687,7 +682,7 @@ a:hover {
   }
 
   .container {
-    padding-inline: max(0.25rem, env(safe-area-inset-left, 0px));
+    padding-inline: max(0.25rem, var(--safe-left));
   }
 
   .section {

--- a/content/styles/root.css
+++ b/content/styles/root.css
@@ -20,9 +20,6 @@
   --success-color: #2d9e47;
 
   /* Background Colors - Dark Mode */
-  --bg-primary: #030303;
-  --bg-secondary: #030303;
-  --bg-tertiary: #030303;
   --bg-interactive: #030303;
 
   /* Text Colors - Optimized for Dark Mode */
@@ -53,16 +50,12 @@
      ============================================ */
 
   --spacing-xxs: 0.1rem; /* 1.6px */
-  --spacing-xs: 0.25rem; /* 4px */
-  --spacing-sm: 0.5rem; /* 8px */
-  --spacing-md: 1rem; /* 16px */
   --spacing-lg: 2rem; /* 32px */
   --spacing-xl: 3rem; /* 48px */
   --spacing-2xl: 5rem; /* 80px */
 
   /* Layout Spacing */
   --container-width: 1600px;
-  --pad-x: clamp(1rem, 4vw, 2rem);
   --gap: clamp(0.75rem, 3vw, 1.5rem);
 
   /* ============================================

--- a/content/styles/root.css
+++ b/content/styles/root.css
@@ -65,18 +65,6 @@
   --pad-x: clamp(1rem, 4vw, 2rem);
   --gap: clamp(0.75rem, 3vw, 1.5rem);
 
-  /* Safe Area Insets */
-  --safe-top: env(safe-area-inset-top, 0);
-  --safe-bottom: env(safe-area-inset-bottom, 0);
-  --safe-left: env(safe-area-inset-left, 0);
-  --safe-right: env(safe-area-inset-right, 0);
-
-  /* Dynamic Layout Spacing - Menu & Footer */
-  --menu-height: 76px; /* 52px + 12px top + 12px spacing */
-  --footer-height: 76px; /* 52px + 12px bottom + 12px spacing */
-  --content-top-offset: calc(var(--menu-height) + var(--safe-top));
-  --content-bottom-offset: calc(var(--footer-height) + var(--safe-bottom));
-
   /* ============================================
      TYPOGRAPHY
      ============================================ */
@@ -284,13 +272,6 @@
      ============================================ */
 
   /* Responsive tweaks: slightly smaller headings on very small viewports */
-  @media (width <= 768px) {
-    :root {
-      --menu-height: 64px; /* 48px + 8px top + 8px spacing */
-      --footer-height: 64px; /* 48px + 8px bottom + 8px spacing */
-    }
-  }
-
   @media (width <= 420px) {
     :root {
       --headline-fs: clamp(2.2rem, 8vw, 3rem);

--- a/content/styles/variables.css
+++ b/content/styles/variables.css
@@ -43,9 +43,21 @@
   --spacing-lg: 1.5rem;
   --spacing-xl: 2rem;
 
-  /* Layout spacing - Header height now managed via --menu-height in root.css */
-  --pad-x: max(1rem, env(safe-area-inset-left));
+  /* Layout spacing */
+  --pad-x: max(1rem, var(--safe-left));
   --pad-y: 1rem;
+
+  /* Safe Area Insets - Native Device Values */
+  --safe-top: env(safe-area-inset-top, 0);
+  --safe-bottom: env(safe-area-inset-bottom, 0);
+  --safe-left: env(safe-area-inset-left, 0);
+  --safe-right: env(safe-area-inset-right, 0);
+
+  /* Dynamic Layout Spacing - Menu & Footer */
+  --menu-height: 76px; /* 52px + 12px top + 12px spacing */
+  --footer-height: 76px; /* 52px + 12px bottom + 12px spacing */
+  --content-top-offset: calc(var(--menu-height) + var(--safe-top));
+  --content-bottom-offset: calc(var(--footer-height) + var(--safe-bottom));
 
   /* ========================================
      BORDERS & RADIUS
@@ -161,4 +173,15 @@
   --section3-leading-lg: 1.5;
   --section3-leading-md: 1.4;
   --section3-leading-sm: 1.3;
+}
+
+/* ========================================
+   RESPONSIVE OVERRIDES
+   ======================================== */
+
+@media (width <= 768px) {
+  :root {
+    --menu-height: 64px; /* 48px + 8px top + 8px spacing */
+    --footer-height: 64px; /* 48px + 8px bottom + 8px spacing */
+  }
 }

--- a/pages/home/section3.css
+++ b/pages/home/section3.css
@@ -151,7 +151,7 @@
     padding: 1rem 0;
   }
   .section3__container {
-    padding: 1.5rem 0.8rem calc(2.25rem + env(safe-area-inset-bottom, 0px));
+    padding: 1.5rem 0.8rem calc(2.25rem + var(--safe-bottom));
     font-size: 0.85rem;
     min-height: 100%;
   }


### PR DESCRIPTION
- Centralized all Safe Area (`--safe-*`) and layout (`--menu-height`, etc.) variables in `content/styles/variables.css`.
- Removed duplicate definitions from `content/styles/root.css` and `content/styles/main.css`.
- Updated `content/styles/main.css` and `pages/home/section3.css` to use the standardized variables instead of manual `env()` calls.
- Updated `content/components/particles/earth/cards.js` to read computed `--safe-top` values instead of using hardcoded fallbacks, ensuring correct layout on notched devices.
- Verified changes via Playwright emulation of iPhone 12 Pro.

---
*PR created automatically by Jules for task [4464583422169201087](https://jules.google.com/task/4464583422169201087) started by @aKs030*