### PR TITLE
⚡ Bolt: Optimize RobotCompanion scroll performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-23 - Robot Companion Layout Thrashing
+
+**Learning:** The `RobotCompanion` class was forcing a synchronous layout reflow on every scroll event (throttled by rAF).
+The code was resetting `style.bottom = ''` (Write) followed immediately by `getBoundingClientRect()` (Read) to check for footer overlap.
+This "Write -> Read" pattern invalidates the layout and forces the browser to recalculate styles and layout synchronously, which is expensive, especially during scrolling.
+
+**Action:** Refactored the overlap check to calculate the theoretical position based on `window.innerHeight` and the known default CSS value (30px). This allows removing the initial style reset, turning the operation into a pure Read (which can use cached layout values) followed by a conditional Write. This eliminates the forced reflow.

--- a/content/components/robot-companion/robot-companion.js
+++ b/content/components/robot-companion/robot-companion.js
@@ -213,13 +213,18 @@ export class RobotCompanion {
       const footer = this.dom.footer;
       if (!footer) return;
 
-      this.dom.container.style.bottom = '';
-      const rect = this.dom.container.getBoundingClientRect();
+      // OPTIMIZATION: Avoid resetting bottom to '' before reading rect to prevent layout thrashing.
+      // Assumes default CSS bottom is 30px.
+      const defaultBottom = 30;
+      const viewportBottom = window.innerHeight;
+      const robotBottom = viewportBottom - defaultBottom;
       const fRect = footer.getBoundingClientRect();
-      const overlap = Math.max(0, rect.bottom - fRect.top);
+      const overlap = robotBottom - fRect.top;
 
       if (overlap > 0) {
-        this.dom.container.style.bottom = `${30 + overlap}px`;
+        this.dom.container.style.bottom = `${defaultBottom + overlap}px`;
+      } else if (this.dom.container.style.bottom) {
+        this.dom.container.style.bottom = '';
       }
 
       if (!this.chatModule.isOpen) {


### PR DESCRIPTION
Refactored `checkOverlap` in `RobotCompanion.js` to avoid resetting `style.bottom` before reading layout dimensions, eliminating forced synchronous reflows on scroll events.

The optimization assumes a default bottom offset of 30px (matching CSS) and calculates the overlap theoretically, reducing the operation to a Read-Only phase in most cases, or Read-Write without invalidation loops.

---
*PR created automatically by Jules for task [1740522414870771530](https://jules.google.com/task/1740522414870771530) started by @aKs030*