### PR TITLE
Fix production build asset injection

### DIFF
--- a/vite-plugin-html-templates.js
+++ b/vite-plugin-html-templates.js
@@ -54,7 +54,7 @@ export default function htmlTemplatesPlugin(options = {}) {
     },
 
     transformIndexHtml: {
-      order: 'post', // Run after Vite's built-in transforms
+      order: 'pre', // Run before Vite's built-in transforms to allow asset resolution
       handler(html, ctx) {
         let transformed = html;
         let headInjected = false;


### PR DESCRIPTION
The production build was failing to load styles and scripts because `vite-plugin-html-templates.js` was injecting `base-head.html` (containing `<link>` and `<script>` tags) using `order: 'post'`.

In `'post'` mode, Vite's transformation pipeline has already finished resolving assets, so the injected tags were treated as raw HTML. This caused the browser to request source paths (e.g., `/content/styles/root.css`) which do not exist in the production `dist` output, leading to 404 errors and a "white screen" (Flash of Unstyled Content) where only the fallback "CSS-Modus" text was visible.

By changing the order to `'pre'`, the templates are injected *before* Vite processes the HTML. This allows Vite to:
1.  Discover the referenced assets (CSS, JS).
2.  Bundle and hash them correctly (e.g., `assets/root.hash.css`).
3.  Rewrite the URLs in the final HTML to point to the bundled assets.

This fixes the "hanging" loading screen in production while maintaining correct behavior in development.

---
*PR created automatically by Jules for task [13695922779762325182](https://jules.google.com/task/13695922779762325182) started by @aKs030*