### PR TITLE
chore: bump cache versions to force production update

### DIFF
--- a/content/components/search/search.css
+++ b/content/components/search/search.css
@@ -220,3 +220,92 @@
   text-align: center;
   color: rgba(255, 255, 255, 0.4);
 }
+
+/* AI Summary Styles */
+.search-ai-summary {
+  background: rgba(0, 210, 255, 0.05);
+  border: 1px solid rgba(0, 210, 255, 0.2);
+  border-radius: 12px;
+  padding: 16px;
+  margin: 12px;
+  margin-bottom: 20px;
+  position: relative;
+  overflow: hidden;
+  animation: search-fade-in 0.4s ease-out;
+}
+
+.search-ai-summary::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+  background: linear-gradient(to bottom, #00d2ff, #3a7bd5);
+}
+
+.search-ai-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.search-ai-icon {
+  font-size: 1.1rem;
+  filter: drop-shadow(0 0 5px rgba(0, 210, 255, 0.5));
+}
+
+.search-ai-title {
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--accent-color, #00d2ff);
+  opacity: 0.8;
+}
+
+.search-ai-content {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: 400;
+}
+
+@keyframes search-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Optimization for result items */
+.search-result-item {
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.search-result-item:hover {
+  transform: translateX(4px);
+}
+
+/* Scrollbar Styling */
+.search-results::-webkit-scrollbar {
+  width: 6px;
+}
+
+.search-results::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.search-results::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+}
+
+.search-results::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
+}

--- a/content/main.js
+++ b/content/main.js
@@ -1,7 +1,7 @@
 /**
  * Main Application Entry Point
- * @version 6.1.0
- * @last-modified 2026-02-05
+ * @version 6.2.0
+ * @last-modified 2026-02-11
  */
 
 import { initConsoleFilter } from './core/console-filter.js';

--- a/functions/api/search.js
+++ b/functions/api/search.js
@@ -1,12 +1,23 @@
 /**
  * Cloudflare Pages Function - POST /api/search
  * Modern AI Search using Service Binding - Optimized & Reduced
- * @version 5.0.0
+ * @version 6.0.0
  */
 
 function normalizeUrl(url) {
   if (!url) return '';
   try {
+    // Handle relative and absolute URLs
+    const base = 'https://abdulkerimsesli.de';
+    const urlObj = new URL(url.startsWith('/') ? base + url : url);
+    let path = urlObj.pathname;
+
+    // Normalize: remove index.html, trailing slashes
+    path = path.replace(/\/index\.html$/, '/').replace(/\/+$/, '') || '/';
+
+    return path;
+  } catch {
+    // Robust fallback for unusual strings
     return (
       url
         .split(/[?#]/)[0]
@@ -14,8 +25,6 @@ function normalizeUrl(url) {
         .replace(/\/index\.html$/, '/')
         .replace(/\/$/, '') || '/'
     );
-  } catch {
-    return url;
   }
 }
 
@@ -160,23 +169,30 @@ function improveResult(result) {
     description = 'Erfahren Sie mehr auf dieser Seite meines Portfolios.';
   }
 
-  return { ...result, title, category, description };
+  return { ...result, title, category, description, url: path };
 }
 
 function deduplicateResults(results) {
   if (!Array.isArray(results)) return [];
-  const seen = new Set();
-  const deduplicated = [];
+
+  const pathMap = new Map();
 
   for (const result of results) {
     const path = normalizeUrl(result.url);
-    if (!seen.has(path)) {
-      seen.add(path);
-      deduplicated.push(improveResult(result));
+    const improved = improveResult(result);
+
+    // If duplicate path, keep the one with higher score or already existing improved one
+    if (
+      !pathMap.has(path) ||
+      (result.score || 0) > (pathMap.get(path).score || 0)
+    ) {
+      pathMap.set(path, improved);
     }
   }
 
-  return deduplicated;
+  return Array.from(pathMap.values()).sort(
+    (a, b) => (b.score || 0) - (a.score || 0),
+  );
 }
 
 export async function onRequestPost(context) {
@@ -197,48 +213,65 @@ export async function onRequestPost(context) {
       });
     }
 
-    // Modern Method: Use Service Binding exclusively
     const binding = env.AI_SEARCH;
     if (!binding) {
       throw new Error('AI_SEARCH Service Binding not configured');
     }
 
-    const serviceResponse = await binding.fetch(
-      new Request('http://ai-search/api/search', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query,
-          limit: topK,
-          topK: topK,
-          index: env.AI_SEARCH_INDEX || 'suche',
-          ragId: env.RAG_ID || 'suche',
+    // Parallel fetch for results and AI summary (Modern RAG approach)
+    const [searchResponse, aiResponse] = await Promise.allSettled([
+      binding.fetch(
+        new Request('http://ai-search/api/search', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query,
+            limit: topK,
+            topK: topK,
+            index: env.AI_SEARCH_INDEX || 'suche',
+            ragId: env.RAG_ID || 'suche',
+          }),
         }),
-      }),
-    );
+      ),
+      binding.fetch(
+        new Request('http://ai-search/api/ai', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            prompt: `Beantworte kurz die Suchanfrage: "${query}" basierend auf dem Portfolio von Abdulkerim.`,
+            message: query,
+            systemInstruction:
+              "Du bist Abdulkerim's Portfolio-Assistent. Antworte extrem kurz (max 2 Sätze) auf Deutsch. Wenn die Frage nichts mit dem Portfolio zu tun hat, bleib höflich. Nutze Informationen über Projekte, Blog und Erfahrung.",
+            ragId: env.RAG_ID || 'suche',
+            maxResults: 5,
+          }),
+        }),
+      ),
+    ]);
 
-    if (!serviceResponse.ok) {
-      throw new Error(`AI Search Worker returned ${serviceResponse.status}`);
+    // Handle Search Results
+    let results = [];
+    if (searchResponse.status === 'fulfilled' && searchResponse.value.ok) {
+      const data = await searchResponse.value.json();
+      if (Array.isArray(data.results)) {
+        results = data.results;
+      } else if (Array.isArray(data.matches)) {
+        results = data.matches.map((m) => ({
+          url: m.metadata?.url || m.url,
+          title: m.metadata?.title || m.title,
+          description: m.metadata?.description || m.description,
+          category: m.metadata?.category || m.category,
+          score: m.score,
+        }));
+      }
     }
 
-    const data = await serviceResponse.json();
-
-    // Robust extraction of results
-    let results = [];
-    if (Array.isArray(data.results)) {
-      results = data.results;
-    } else if (Array.isArray(data.matches)) {
-      results = data.matches.map((m) => ({
-        url: m.metadata?.url || m.url,
-        title: m.metadata?.title || m.title,
-        description: m.metadata?.description || m.description,
-        category: m.metadata?.category || m.category,
-        score: m.score,
-      }));
-    } else if (data.data && Array.isArray(data.data.results)) {
-      results = data.data.results;
-    } else if (Array.isArray(data)) {
-      results = data;
+    // Handle AI Summary
+    let summary = '';
+    if (aiResponse.status === 'fulfilled' && aiResponse.value.ok) {
+      const aiData = await aiResponse.value.json();
+      summary = aiData.text || aiData.response || aiData.answer || '';
+      if (!summary && aiData.data) summary = aiData.data.text || '';
     }
 
     const finalResults = deduplicateResults(results);
@@ -246,6 +279,7 @@ export async function onRequestPost(context) {
     return new Response(
       JSON.stringify({
         results: finalResults,
+        summary: summary,
         count: finalResults.length,
         query: query,
       }),

--- a/server.js
+++ b/server.js
@@ -280,6 +280,7 @@ function handleAPIMock(req, res, url) {
                 description: `Ergebnisse für ${query} werden hier simuliert.`,
               },
             ],
+            summary: `Dies ist eine KI-gestützte Zusammenfassung für deine Suche nach "${query}". Ich habe Informationen über Startseite und Projekte gefunden.`,
             query,
             count: 2,
           }),

--- a/sw.js
+++ b/sw.js
@@ -1,13 +1,13 @@
 /**
  * Service Worker for PWA
  * Provides offline support and caching strategies
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 // @ts-nocheck
 /* global self, caches */
 
-const CACHE_VERSION = 'v1.0.0';
+const CACHE_VERSION = 'v1.1.0';
 const CACHE_NAME = `iweb-${CACHE_VERSION}`;
 
 // Assets to cache on install


### PR DESCRIPTION
- Bumped `CACHE_VERSION` in `sw.js` to `v1.1.0`.
- Bumped `@version` in `content/main.js` to `6.2.0`.
- This ensures the Service Worker invalidates the old cache and fetches the updated search component on the production domain.