### PR TITLE
Fix SEO duplicate content and robots.txt configuration

### DIFF
--- a/content/components/footer/footer.html
+++ b/content/components/footer/footer.html
@@ -270,7 +270,7 @@
               </svg>
               <span data-i18n="footer.work.projects">Projekte</span>
             </a>
-            <a href="/pages/blog/">
+            <a href="/blog/">
               <svg
                 width="12"
                 height="12"
@@ -323,7 +323,7 @@
         <article class="card">
           <h2 data-i18n="footer.quick_links.title">Quick Links</h2>
           <nav class="links links-compact" aria-label="Quick Links Navigation">
-            <a href="/pages/gallery/">
+            <a href="/gallery/">
               <svg
                 width="12"
                 height="12"
@@ -338,7 +338,7 @@
               </svg>
               <span data-i18n="footer.quick_links.gallery">Galerie</span>
             </a>
-            <a href="/pages/videos/">
+            <a href="/videos/">
               <svg
                 width="12"
                 height="12"
@@ -352,7 +352,7 @@
               </svg>
               <span data-i18n="footer.quick_links.videos">Videos</span>
             </a>
-            <a href="/pages/about/">
+            <a href="/about/">
               <svg
                 width="12"
                 height="12"

--- a/pages/about/index.html
+++ b/pages/about/index.html
@@ -251,7 +251,7 @@
           <div class="about__exp-footer">
             <div class="about__section-cta u-row u-between">
               <h3>Coding Playground</h3>
-              <a href="/projekte" class="about__link--accent"
+              <a href="/projekte/" class="about__link--accent"
                 >Alle Projekte →</a
               >
             </div>

--- a/robots.txt
+++ b/robots.txt
@@ -8,11 +8,27 @@ Sitemap: https://www.abdulkerimsesli.de/sitemap-videos.xml
 User-agent: *
 Allow: /
 
-# Block raw internal HTML fragments (not needed for indexing)
-Disallow: /content/components/*.html
-Disallow: /content/components/*/*.html
+# Block internal implementation directories
+Disallow: /content/components/
+Disallow: /pages/
 
-# Allow resources Googlebot needs for rendering (CSS, JS, XHR partials)
+# Allow resources Googlebot needs for rendering (CSS, JS, Fonts, Images globally)
+Allow: /*.css$
+Allow: /*.js$
+Allow: /*.png$
+Allow: /*.jpg$
+Allow: /*.jpeg$
+Allow: /*.gif$
+Allow: /*.svg$
+Allow: /*.webp$
+Allow: /*.woff$
+Allow: /*.woff2$
+Allow: /*.ttf$
+Allow: /*.eot$
+Allow: /*.ico$
+Allow: /*.json$
+
+# Explicitly allow footer partials required for JS rendering (overrides Disallow /content/components/)
 Allow: /content/components/footer/footer.html
 Allow: /content/components/footer/footer
 Allow: /content/components/footer/datenschutz.html
@@ -20,25 +36,17 @@ Allow: /content/components/footer/impressum.html
 Allow: /content/components/footer/datenschutz/
 Allow: /content/components/footer/impressum/
 
-# Block page HTML partials but allow CSS/JS assets needed for rendering
-Disallow: /pages/*.html
-Disallow: /pages/*/*.html
-Allow: /pages/*.css
-Allow: /pages/*/*.css
-Allow: /pages/*.js
-Allow: /pages/*/*.js
-
-# Block non-HTML resources that shouldn't be indexed
-Allow: /manifest.json
-Disallow: /files/
+# Block non-HTML resources that shouldn't be indexed but technically allowed above? No, Allow wins.
+# But allow json is good (manifest.json).
+# Disallow specific query params
 Disallow: /*?search=
 Disallow: /*?q=
 
 # Block internal/system paths
-# Note: Allowing /content/config and /content/utils so Google can load scripts required for rendering
 Disallow: /node_modules/
 Disallow: /tmp/
 Disallow: /dev/
+Disallow: /files/
 
 # Block aggressive crawlers
 User-agent: AhrefsBot


### PR DESCRIPTION
This PR addresses SEO issues related to duplicate content and crawl efficiency.
It updates internal links in the footer and about page to point to canonical URLs (e.g., `/blog/`) instead of physical file paths (`/pages/blog/`).
Additionally, `robots.txt` has been hardened to prevent Googlebot from crawling the `/pages/` and `/content/components/` directories, which were sources of duplicate content, while ensuring that all necessary assets (CSS, JS, images) remain crawlable for proper rendering.

---
*PR created automatically by Jules for task [6618513601145054428](https://jules.google.com/task/6618513601145054428) started by @aKs030*