### PR TITLE
Fix structured data errors for Datenschutz and Impressum pages

### DIFF
--- a/content/config/routes-config.js
+++ b/content/config/routes-config.js
@@ -60,4 +60,18 @@ export const ROUTES = {
     type: 'AboutPage',
     image: `${BASE_URL}/content/assets/img/og/og-home-800.webp`,
   },
+  '/datenschutz/': {
+    title: 'Datenschutzerklärung | Abdulkerim Sesli',
+    description:
+      'Informationen zum Datenschutz und zur Verarbeitung personenbezogener Daten gemäß DSGVO.',
+    type: 'WebPage',
+    image: `${BASE_URL}/content/assets/img/og/og-home-800.webp`,
+  },
+  '/impressum/': {
+    title: 'Impressum | Abdulkerim Sesli',
+    description:
+      'Rechtliche Anbieterkennzeichnung und Kontaktinformationen gemäß TMG.',
+    type: 'WebPage',
+    image: `${BASE_URL}/content/assets/img/og/og-home-800.webp`,
+  },
 };


### PR DESCRIPTION
Fixed Google Search Console structured data errors for `/datenschutz/` and `/impressum/` pages. The issue was traced to these pages falling back to the default `ProfilePage` schema configuration because they were missing from `content/config/routes-config.js`.

I added explicit entries for these routes, defining them as `WebPage` with appropriate titles and descriptions. This ensures the generated JSON-LD is syntactically correct and semantically appropriate, preventing the "Fehlerhafter Aufbau: „,“ oder „]“ fehlt in Array-Beschreibung" (Malformatted structure) error which likely stemmed from inappropriate schema properties being applied or GSC confusion over the type.

Verified the fix by simulating the schema generation process, which now produces valid `WebPage` JSON-LD for these routes.

---
*PR created automatically by Jules for task [9918081249067965918](https://jules.google.com/task/9918081249067965918) started by @aKs030*