### PR TITLE
chore: configure R2 bucket for gallery images

### DIFF
--- a/content/config/R2_CORS.json
+++ b/content/config/R2_CORS.json
@@ -1,0 +1,15 @@
+[
+  {
+    "AllowedOrigins": [
+      "https://abdulkerimsesli.de",
+      "https://www.abdulkerimsesli.de",
+      "http://localhost:5173",
+      "http://127.0.0.1:8788",
+      "https://1web.pages.dev"
+    ],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": [],
+    "MaxAgeSeconds": 3000
+  }
+]

--- a/pages/gallery/config.js
+++ b/pages/gallery/config.js
@@ -1,3 +1,8 @@
+/**
+ * Gallery Configuration
+ * Assets are hosted on Cloudflare R2 via custom domain (img.abdulkerimsesli.de).
+ * Ensure the R2 bucket has the CORS policy defined in `content/config/R2_CORS.json`.
+ */
 export const GALLERY_ITEMS = [
   {
     id: 'mond',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,6 +15,11 @@ MAX_SEARCH_RESULTS = "10"
 binding = "BUCKET"
 bucket_name = "ai-search-suche-92e832"
 
+# R2 Bucket für die Galerie-Bilder (img.abdulkerimsesli.de)
+[[r2_buckets]]
+binding = "GALLERY_BUCKET"
+bucket_name = "img"
+
 # Vectorize Index für die KI-Suche
 [[vectorize]]
 binding = "VECTOR_INDEX"


### PR DESCRIPTION
This PR configures the project to use the Cloudflare R2 bucket (`img`) for gallery images.

### Actions Required by User:
1.  **Apply CORS Policy:** Go to your Cloudflare Dashboard > R2 > Select bucket `img` > Settings > CORS Policy.
2.  Open the file `content/config/R2_CORS.json` from this PR.
3.  Copy the JSON content and paste it into the Cloudflare CORS settings.
    *   This is required for the 3D Gallery (WebGL) to load images from `img.abdulkerimsesli.de`.

### Changes:
-   Updated `wrangler.toml` to include the `GALLERY_BUCKET` binding.
-   Added `content/config/R2_CORS.json`.
-   Added documentation to `pages/gallery/config.js`.

---
*PR created automatically by Jules for task [433307981873411848](https://jules.google.com/task/433307981873411848) started by @aKs030*