### PR TITLE
Fix robot magnifying glass clipping and restore flame appearance

### DIFF
--- a/content/components/robot-companion/dom/RobotDOMBuilder.js
+++ b/content/components/robot-companion/dom/RobotDOMBuilder.js
@@ -325,7 +325,23 @@ export class RobotDOMBuilder {
 
     lidGradient.append(stop1, stop2);
 
-    defs.append(glowFilter, lidShadowFilter, lidGradient);
+    // Flame clip path (to keep flame contained within original bounds while allowing overflow elsewhere)
+    const flameClip = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'clipPath',
+    );
+    flameClip.setAttribute('id', 'flame-clip');
+    const flameRect = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'rect',
+    );
+    flameRect.setAttribute('x', '0');
+    flameRect.setAttribute('y', '0');
+    flameRect.setAttribute('width', '100');
+    flameRect.setAttribute('height', '100');
+    flameClip.appendChild(flameRect);
+
+    defs.append(glowFilter, lidShadowFilter, lidGradient, flameClip);
 
     return defs;
   }
@@ -520,6 +536,8 @@ export class RobotDOMBuilder {
     const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
     g.classList.add('robot-flame');
     g.style.opacity = '0';
+    // Apply clip-path to restore original clipping behavior for the flame
+    g.setAttribute('clip-path', 'url(#flame-clip)');
 
     const outerFlame = document.createElementNS(
       'http://www.w3.org/2000/svg',

--- a/content/components/robot-companion/robot-companion.css
+++ b/content/components/robot-companion/robot-companion.css
@@ -38,6 +38,7 @@
   isolation: isolate;
   will-change: transform;
   animation: cyberGlitch 12s infinite;
+  overflow: visible;
 }
 
 .robot-avatar::after,
@@ -219,6 +220,7 @@
   height: 100%;
   transition: transform 0.4s ease;
   will-change: transform;
+  overflow: visible;
 }
 
 .robot-flame {


### PR DESCRIPTION
This change allows the magnifying glass in the robot companion to extend beyond the SVG viewBox (fixing the issue where it was cut off) by setting `overflow: visible` on the robot's SVG and avatar container. 

To prevent the robot's flame animation from appearing incorrectly (too long/unclipped) due to this change, a `clipPath` has been added to the SVG definitions and applied specifically to the `.robot-flame` element, restoring its original clipped appearance.

---
*PR created automatically by Jules for task [8036791595517461941](https://jules.google.com/task/8036791595517461941) started by @aKs030*