### PR TITLE
Allow Googlebot access to component HTML and fix Schema warning

### DIFF
--- a/content/core/schema.js
+++ b/content/core/schema.js
@@ -92,6 +92,7 @@ export function generateSchemaGraph(
       '@type': 'ImageObject',
       '@id': `${ENV.BASE_URL}/#personImage`,
       url: 'https://commons.wikimedia.org/wiki/File:Abdulkerim_Sesli_portrait_2025.png',
+      creator: { '@type': 'Person', name: brandData.name },
       caption: brandData.name,
       license: `${ENV.BASE_URL}/#image-license`,
       acquireLicensePage: `${ENV.BASE_URL}/#image-license`,

--- a/robots.txt
+++ b/robots.txt
@@ -9,6 +9,15 @@ Allow: /
 # Erlaube Zugriff auf den Pages-Ordner für korrektes Rendering und Indexierung
 Allow: /pages/
 
+# Erlaube wichtige Ressourcen in Komponenten (CSS, JS, Bilder)
+Allow: /content/components/*.js
+Allow: /content/components/*.css
+Allow: /content/components/*.svg
+Allow: /content/components/*.png
+Allow: /content/components/*.jpg
+Allow: /content/components/*.webp
+Allow: /content/components/*.html
+
 # Blockiere nur rein technische Komponenten und System-Pfade
 Disallow: /content/components/
 Disallow: /node_modules/


### PR DESCRIPTION
This change addresses two SEO/crawling issues:

1.  **Robots.txt Blocking:** Updated `robots.txt` to explicitly allow crawling of `.html` files in `/content/components/`. This resolves the "Footer load failed" error caused by Googlebot being unable to fetch the dynamically loaded `footer.html`.

2.  **Schema.org Warning:** Added the missing `creator` field to the `ImageObject` schema definition for the profile picture (`Abdulkerim_Sesli_portrait_2025.png`) in `content/core/schema.js`. This resolves the Google Search Console warning about the missing creator field.