### PR TITLE
Fix WebGL context leak by stabilizing useTranslation hook

### DIFF
--- a/content/core/react-utils.js
+++ b/content/core/react-utils.js
@@ -20,6 +20,10 @@ export const createUseTranslation = (React) => {
       return () => i18n.removeEventListener('language-changed', onLangChange);
     }, []);
 
-    return { t: (key, params) => i18n.t(key, params), lang };
+    // Stabilize the t function reference so it doesn't change on every render
+    const t = React.useCallback((key, params) => i18n.t(key, params), [lang]);
+
+    // Return memoized object to prevent unnecessary re-renders in consumers
+    return React.useMemo(() => ({ t, lang }), [t, lang]);
   };
 };


### PR DESCRIPTION
This PR fixes a critical issue where "Too many active WebGL contexts" errors were occurring due to an infinite re-render loop in `GalleryApp`.

The root cause was the `createUseTranslation` hook returning a new function reference on every render, which triggered `useEffect` in `GalleryApp`, which in turn fetched data and updated state, causing another render. This cycle caused rapid creation and destruction of the 3D scene and WebGL contexts.

Changes:
1.  **`content/core/react-utils.js`**: Wrapped `t` function in `useCallback` and the return object in `useMemo` to ensure referential stability.
2.  **`pages/gallery/gallery-app.js`**:
    *   Moved data fetching logic to a separate `useEffect` with an empty dependency array `[]`.
    *   Added a `useRef` guard to prevent double initialization.
    *   Used `i18n.t` directly for initial loader messages to avoid dependency on the hook's `t` during mount.
    *   Separated schema updates to a distinct effect dependent on `items`.

Verified visually that the gallery loads correctly and remains stable without crashing.

---
*PR created automatically by Jules for task [259961547855944487](https://jules.google.com/task/259961547855944487) started by @aKs030*