### PR TITLE
fix(gallery): add missing creator and creditText to ImageObject schema

### DIFF
--- a/pages/gallery/gallery-app.js
+++ b/pages/gallery/gallery-app.js
@@ -138,6 +138,11 @@ const GalleryApp = () => {
           '@type': 'Person',
           name: 'Abdulkerim Sesli',
         },
+        creator: {
+          '@type': 'Person',
+          name: 'Abdulkerim Sesli',
+        },
+        creditText: 'Photo: Abdulkerim Sesli',
         license: 'https://abdulkerimsesli.de/#image-license',
         acquireLicensePage: 'https://abdulkerimsesli.de/#image-license',
         copyrightNotice: `© ${new Date().getFullYear()} Abdulkerim Sesli`,


### PR DESCRIPTION
This PR updates the structured data generation for gallery images to include `creator` and `creditText` fields. This addresses warnings reported by Google Search Console. The `creator` is set to a Person object for Abdulkerim Sesli, and `creditText` is set to "Photo: Abdulkerim Sesli".

---
*PR created automatically by Jules for task [3906226508762031275](https://jules.google.com/task/3906226508762031275) started by @aKs030*