### PR TITLE
feat(search): Redesign Search to Spotlight Style

### DIFF
--- a/content/components/search/search.css
+++ b/content/components/search/search.css
@@ -1,13 +1,13 @@
-/* Search specific styles */
+/* Search specific styles - Spotlight Design */
 .search-overlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: rgba(0, 0, 0, 0.2); /* Reduced opacity for cleaner look */
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
   z-index: 9999;
   display: flex;
   justify-content: center;
@@ -25,68 +25,101 @@
 
 .search-modal {
   width: 100%;
-  max-width: 600px;
-  background: rgba(30, 30, 35, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+  max-width: 800px;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  align-items: center;
   transform: translateY(-20px) scale(0.98);
   transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  background: transparent;
+  box-shadow: none;
+  border: none;
 }
 
 .search-overlay.active .search-modal {
   transform: translateY(0) scale(1);
 }
 
-.search-header {
+/* --- Search Bar Wrapper (Input + Actions) --- */
+.search-bar-wrapper {
   display: flex;
   align-items: center;
-  padding: 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  width: 100%;
+  gap: 12px;
 }
 
-.search-input-wrapper {
+/* --- Input Container (Pill) --- */
+.search-input-container {
   flex: 1;
-  position: relative;
+  height: 60px;
+  background: rgba(40, 40, 45, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 30px;
   display: flex;
   align-items: center;
+  padding: 0 20px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  position: relative;
+  transition: border-color 0.2s;
+}
+
+.search-input-container:focus-within {
+  border-color: rgba(255, 255, 255, 0.3);
 }
 
 .search-icon {
-  position: absolute;
-  left: 12px;
-  color: rgba(255, 255, 255, 0.4);
-  font-size: 1.1em;
-  pointer-events: none;
+  color: rgba(255, 255, 255, 0.5);
+  margin-right: 12px;
+  display: flex;
+  align-items: center;
 }
 
 .search-input {
-  width: 100%;
+  flex: 1;
   background: transparent;
   border: none;
   color: #fff;
-  font-size: 18px;
-  padding: 12px 12px 12px 42px;
+  font-size: 20px;
   font-family: inherit;
   outline: none;
+  height: 100%;
 }
 
 .search-input::placeholder {
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.search-close {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-left: 10px;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.search-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
 }
 
 .search-loader {
-  position: absolute;
-  right: 12px;
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   border: 2px solid rgba(255, 255, 255, 0.1);
   border-top-color: var(--accent-color, #00d2ff);
   border-radius: 50%;
   animation: search-spin 0.6s linear infinite;
+  margin-left: 10px;
 }
 
 @keyframes search-spin {
@@ -95,31 +128,64 @@
   }
 }
 
-.search-close {
-  background: transparent;
-  border: none;
-  color: rgba(255, 255, 255, 0.5);
-  padding: 8px;
-  margin-left: 8px;
-  cursor: pointer;
-  border-radius: 4px;
+/* --- Quick Actions --- */
+.search-quick-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.search-action-btn {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: rgba(40, 40, 45, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.7);
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
-.search-close:hover {
-  background: rgba(255, 255, 255, 0.1);
+.search-action-btn:hover {
+  transform: translateY(-2px);
+  background: rgba(60, 60, 65, 0.9);
   color: #fff;
+  border-color: rgba(255, 255, 255, 0.3);
 }
 
+.search-action-btn svg {
+  width: 24px;
+  height: 24px;
+}
+
+/* --- Results Container --- */
 .search-results {
+  width: 100%;
+  margin-top: 16px;
+  background: rgba(30, 30, 35, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
   max-height: 60vh;
   overflow-y: auto;
   padding: 8px;
   overscroll-behavior: contain;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+  display: none;
 }
 
+.search-results:not(:empty) {
+  display: block;
+  animation: search-fade-in 0.2s ease-out;
+}
+
+/* Stats */
 .search-stats {
   padding: 8px 12px;
   font-size: 0.8rem;
@@ -130,6 +196,7 @@
   margin-bottom: 4px;
 }
 
+/* Category Groups */
 .search-category-group {
   margin-bottom: 12px;
 }
@@ -151,6 +218,7 @@
   background: rgba(255, 255, 255, 0.05);
 }
 
+/* Result Items */
 .search-result-item {
   display: flex;
   align-items: center;
@@ -215,10 +283,17 @@
   border-radius: 2px;
 }
 
+/* Empty State */
 .search-empty {
   padding: 40px;
   text-align: center;
   color: rgba(255, 255, 255, 0.4);
+}
+
+.search-empty-icon {
+  font-size: 3rem;
+  margin-bottom: 12px;
+  opacity: 0.3;
 }
 
 /* AI Summary Styles */
@@ -283,15 +358,6 @@
   }
 }
 
-/* Optimization for result items */
-.search-result-item {
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.search-result-item:hover {
-  transform: translateX(4px);
-}
-
 /* Scrollbar Styling */
 .search-results::-webkit-scrollbar {
   width: 6px;
@@ -310,86 +376,32 @@
   background: rgba(255, 255, 255, 0.2);
 }
 
-/* Autocomplete Suggestions */
-.search-autocomplete {
-  background: rgba(20, 20, 25, 0.95);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  max-height: 200px;
-  overflow-y: auto;
-}
-
-.search-autocomplete-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.search-autocomplete-item:hover {
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.search-autocomplete-icon {
-  font-size: 0.9rem;
-  opacity: 0.5;
-}
-
-.search-autocomplete-text {
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.search-did-you-mean {
-  margin-top: 20px;
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 8px;
-}
-
-.search-did-you-mean-title {
-  font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.5);
-  margin-bottom: 10px;
-}
-
-.search-did-you-mean-suggestions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.search-did-you-mean-btn {
-  padding: 8px 16px;
-  background: rgba(0, 210, 255, 0.1);
-  border: 1px solid rgba(0, 210, 255, 0.3);
-  border-radius: 20px;
-  color: var(--accent-color, #00d2ff);
-  font-size: 0.9rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.search-did-you-mean-btn:hover {
-  background: rgba(0, 210, 255, 0.2);
-  border-color: var(--accent-color, #00d2ff);
-  transform: translateY(-1px);
-}
-
-/* Enhanced Empty State */
-.search-empty-icon {
-  font-size: 3rem;
-  margin-bottom: 12px;
-  opacity: 0.3;
-}
-
 /* Responsive Design */
 @media (max-width: 768px) {
   .search-modal {
     max-width: 95%;
     margin: 0 auto;
+  }
+
+  .search-bar-wrapper {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .search-input-container {
+    width: 100%;
+    flex: none;
+  }
+
+  .search-quick-actions {
+    width: 100%;
+    justify-content: center;
+    margin-top: 10px;
+  }
+
+  .search-action-btn {
+    width: 50px;
+    height: 50px;
   }
 }
 

--- a/content/components/search/search.css
+++ b/content/components/search/search.css
@@ -85,6 +85,14 @@
   font-family: inherit;
   outline: none;
   height: 100%;
+  appearance: none;
+  -webkit-appearance: none;
+  box-shadow: none;
+}
+
+.search-input:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 .search-input::placeholder {

--- a/content/components/search/search.js
+++ b/content/components/search/search.js
@@ -69,28 +69,41 @@ class SearchComponent {
 
     overlay.innerHTML = `
       <div class="search-modal" role="document">
-        <div class="search-header">
-          <div class="search-input-wrapper">
+        <div class="search-bar-wrapper">
+          <div class="search-input-container">
+            <span class="search-icon" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+            </span>
             <input
               type="text"
               id="search-input"
               name="search"
               class="search-input"
-              placeholder="Suche... (KI-gestützt)"
+              placeholder="Suche"
               aria-label="Suchfeld"
               autocomplete="off"
               autocorrect="off"
               autocapitalize="off"
               spellcheck="false"
             >
-            <span class="search-icon" aria-hidden="true">🔍</span>
             <div class="search-loader" style="display: none;"></div>
+            <button class="search-close" aria-label="Suche schließen" title="ESC">✕</button>
           </div>
-          <button class="search-close" aria-label="Suche schließen" title="ESC">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 4L4 12M4 4L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </button>
+
+          <div class="search-quick-actions">
+            <button class="search-action-btn" data-href="/" title="Home">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
+            </button>
+            <button class="search-action-btn" data-href="/projects" title="Projekte">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+            </button>
+            <button class="search-action-btn" data-href="/gallery" title="Galerie">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>
+            </button>
+            <button class="search-action-btn" data-href="/contact" title="Kontakt">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+            </button>
+          </div>
         </div>
 
         <div class="search-results" role="region" aria-live="polite" aria-atomic="false"></div>
@@ -107,6 +120,19 @@ class SearchComponent {
     overlay
       .querySelector('.search-close')
       .addEventListener('click', () => this.close());
+
+    // Quick action buttons
+    overlay.querySelectorAll('.search-action-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        // @ts-ignore
+        const href = btn.dataset.href;
+        if (href) {
+          window.location.href = href;
+          this.close();
+        }
+      });
+    });
+
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) this.close();
     });


### PR DESCRIPTION
Redesigned the search component to match the macOS Spotlight aesthetic. 
- Implemented a pill-shaped search input container.
- Added 4 quick action buttons (Home, Projects, Gallery, Contact) with icons.
- Positioned search results below the input bar.
- Updated CSS for glassmorphism effects and animations.
- Verified frontend functionality and responsiveness.

---
*PR created automatically by Jules for task [1099430082919968521](https://jules.google.com/task/1099430082919968521) started by @aKs030*