### PR TITLE
Fix robot chat window occlusion by mobile keyboard

### DIFF
--- a/content/components/robot-companion/robot-companion.js
+++ b/content/components/robot-companion/robot-companion.js
@@ -279,6 +279,9 @@ export class RobotCompanion {
     if (typeof globalThis === 'undefined' || !globalThis.visualViewport) return;
 
     this._handleViewportResize = () => {
+      // Ensure visualViewport is available
+      if (!window.visualViewport) return;
+
       // Skip if search animation is active
       if (
         this.animationModule.searchAnimation &&
@@ -327,6 +330,13 @@ export class RobotCompanion {
         const maxWindowHeight = visualHeight - safeMargin * 2;
         this.dom.window.style.maxHeight = `${maxWindowHeight}px`;
 
+        // Adjust Chat Window Position to stay centered in Visual Viewport
+        if (this.dom.window) {
+          const visualTop = window.visualViewport.offsetTop;
+          const centerY = visualTop + visualHeight / 2;
+          this.dom.window.style.top = `${centerY}px`;
+        }
+
         requestAnimationFrame(() => {
           if (!this.dom.window) return;
           const currentHeight = this.dom.window.offsetHeight;
@@ -351,6 +361,7 @@ export class RobotCompanion {
         // Reset styles to allow CSS / footer overlap logic to take over
         this.dom.container.style.bottom = '';
         this.dom.window.style.maxHeight = '';
+        this.dom.window.style.top = '';
       }
     };
 


### PR DESCRIPTION
This change implements a dynamic positioning fix for the robot chat window on mobile devices. It listens to `visualViewport` resize events to detect when the software keyboard opens (shrinking the viewport). When detected, it calculates the center of the visible viewport and sets `top` via inline styles to ensure the chat window remains visible and accessible. It also resets the styles when the keyboard closes, allowing CSS to resume control. A safety check for `window.visualViewport` was added to prevent runtime errors in environments where it is not supported.

---
*PR created automatically by Jules for task [16300374993518220104](https://jules.google.com/task/16300374993518220104) started by @aKs030*