### PR TITLE
Fix mobile search overlay layout for viewport-fit=cover

### DIFF
--- a/content/components/search/search.css
+++ b/content/components/search/search.css
@@ -4,15 +4,18 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100dvh; /* Dynamic viewport height to cover address bars */
   background: rgba(0, 0, 0, 0.2); /* Reduced opacity for cleaner look */
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
-  z-index: 9999;
+  z-index: 10002; /* Above header (9999) and skip-links (10001) */
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  padding-top: 20vh;
+  padding-top: calc(20vh + var(--safe-top, 0px));
+  padding-left: var(--safe-left, 0px);
+  padding-right: var(--safe-right, 0px);
+  padding-bottom: var(--safe-bottom, 0px);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
@@ -431,7 +434,7 @@
 
 @media (max-width: 480px) {
   .search-overlay {
-    padding-top: 10vh;
+    padding-top: calc(10vh + var(--safe-top, 0px));
   }
 
   .search-input {


### PR DESCRIPTION
This change updates the search overlay CSS to fully support `viewport-fit=cover` on mobile devices. It introduces `padding-top: calc(20vh + var(--safe-top))` to respect the notch area, and changes `height: 100%` to `100dvh` to ensure the overlay background extends correctly behind dynamic browser UI elements like the address bar. It also bumps the z-index to ensure it sits above the site header.

---
*PR created automatically by Jules for task [8422858191684123640](https://jules.google.com/task/8422858191684123640) started by @aKs030*