### PR TITLE
Strict positive-integer validation for `topK` in search API

### DIFF
--- a/functions/api/search.js
+++ b/functions/api/search.js
@@ -32,7 +32,21 @@ export async function onRequestPost(context) {
       throw new Error('AI binding not configured');
     }
 
-    const topK = parseInt(body.topK || env.MAX_SEARCH_RESULTS || '10');
+    const parsePositiveInteger = (value) => {
+      const normalized = String(value ?? '').trim();
+
+      if (!/^\d+$/.test(normalized)) {
+        return null;
+      }
+
+      const parsed = Number.parseInt(normalized, 10);
+      return parsed > 0 ? parsed : null;
+    };
+
+    const topK =
+      parsePositiveInteger(body.topK) ??
+      parsePositiveInteger(env.MAX_SEARCH_RESULTS) ??
+      10;
 
     // Expand query with synonyms and fuzzy matching
     const expandedQuery = expandQuery(query);


### PR DESCRIPTION
### Motivation
- Prevent partially-numeric or invalid `topK` inputs (e.g. `"10abc"`, empty, zero, negative) from being silently accepted and producing surprising result limits. 
- Provide a clear, deterministic precedence for resolving `topK` between request input and environment defaults.

### Description
- Add a helper `parsePositiveInteger` in `functions/api/search.js` that trims input, enforces a full-digit match with `/^\d+$/`, parses with `Number.parseInt(..., 10)`, and only returns positive integers. 
- Resolve `topK` using the precedence `body.topK` → `env.MAX_SEARCH_RESULTS` → fallback `10`, each only when valid according to the helper. 
- Preserve downstream behavior that calls `Math.max(topK, 15)` for the AI search `max_num_results` and keep the rest of the result transformation logic unchanged.

### Testing
- Ran `npm run lint:check -- functions/api/search.js` which completed successfully. 
- Pre-commit formatting/linters (`eslint --fix` and `prettier --write`) were executed and passed during the change validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f295caa4832da1e4eeb7e0c0ab62)