### PR TITLE
Fix Cloudflare AI search compatibility across AutoRAG API variants

### DIFF
--- a/functions/api/_ai-search.js
+++ b/functions/api/_ai-search.js
@@ -1,0 +1,105 @@
+/**
+ * Cloudflare AI Search compatibility layer.
+ * Supports both legacy and newer AutoRAG method names/response shapes.
+ */
+
+function normalizeSearchItem(item) {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+
+  const filename =
+    item.filename || item.url || item.path || item.source || item.id || '';
+
+  const scoreCandidates = [
+    item.score,
+    item.similarity,
+    item.relevance,
+    item.rank,
+  ];
+  const score =
+    scoreCandidates.find((candidate) => Number.isFinite(candidate)) || 0;
+
+  const content = Array.isArray(item.content)
+    ? item.content
+    : typeof item.content === 'string'
+      ? [{ text: item.content }]
+      : Array.isArray(item.chunks)
+        ? item.chunks.map((chunk) =>
+            typeof chunk === 'string'
+              ? { text: chunk }
+              : { text: chunk?.text || '' },
+          )
+        : [];
+
+  return {
+    ...item,
+    filename,
+    score,
+    content,
+    text: item.text || item.snippet || item.description || '',
+  };
+}
+
+export async function performAutoRagSearch(env, options) {
+  const ragId = options.ragId || env.RAG_ID || 'wispy-pond-1055';
+
+  if (!env.AI || typeof env.AI.autorag !== 'function') {
+    throw new Error('AI binding not configured');
+  }
+
+  const rag = env.AI.autorag(ragId);
+  const payload = {
+    query: options.query,
+    max_num_results: options.maxResults,
+    rewrite_query: options.rewriteQuery,
+    stream: options.stream ?? false,
+  };
+
+  if (options.systemPrompt) {
+    payload.system_prompt = options.systemPrompt;
+  }
+
+  const methodNames = ['aiSearch', 'search', 'query'];
+  let rawResponse = null;
+  let lastError = null;
+
+  for (const methodName of methodNames) {
+    const candidate = rag?.[methodName];
+    if (typeof candidate !== 'function') {
+      continue;
+    }
+
+    try {
+      rawResponse = await candidate.call(rag, payload);
+      break;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (!rawResponse) {
+    if (lastError) {
+      throw lastError;
+    }
+    throw new Error('No compatible AutoRAG search method found');
+  }
+
+  const responseData = Array.isArray(rawResponse?.data)
+    ? rawResponse.data
+    : Array.isArray(rawResponse?.results)
+      ? rawResponse.results
+      : Array.isArray(rawResponse?.documents)
+        ? rawResponse.documents
+        : [];
+
+  return {
+    summary:
+      rawResponse?.response ||
+      rawResponse?.summary ||
+      rawResponse?.answer ||
+      '',
+    data: responseData.map(normalizeSearchItem).filter(Boolean),
+    rawResponse,
+  };
+}

--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -11,6 +11,7 @@ import {
   extractTitle,
   extractContent,
 } from './_search-utils.js';
+import { performAutoRagSearch } from './_ai-search.js';
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const GROQ_MODEL = 'llama-3.3-70b-versatile';
@@ -20,17 +21,13 @@ const GROQ_MODEL = 'llama-3.3-70b-versatile';
  * @returns {Object} { context: string, sources: Array } or null
  */
 async function getRelevantContext(query, env) {
-  if (!env.AI) {
-    return null;
-  }
-
   try {
-    // Use AI Search Beta to get relevant context
-    const searchData = await env.AI.autorag('wispy-pond-1055').aiSearch({
+    const searchData = await performAutoRagSearch(env, {
       query: query,
-      max_num_results: 5,
-      rewrite_query: false,
+      maxResults: 5,
+      rewriteQuery: false,
       stream: false,
+      ragId: 'wispy-pond-1055',
     });
 
     if (!searchData.data || searchData.data.length === 0) {


### PR DESCRIPTION
### Motivation
- Cloudflare AI (AutoRAG) method names and response shapes changed causing the site search and AI context lookups to break, so a compatibility layer is required to make the functions resilient. 
- The goal is to keep the existing ranking, snippet, and deduplication logic while preventing runtime failures when Cloudflare exposes different method names or response fields. 

### Description
- Added a compatibility helper `functions/api/_ai-search.js` that tries multiple AutoRAG method names (`aiSearch`, `search`, `query`), normalizes response shapes and items, and returns a stable `{ summary, data, rawResponse }` surface. 
- Updated `functions/api/search.js` to call the new `performAutoRagSearch` helper and to use the normalized `summary` and item fields for downstream snippet, scoring and deduplication logic. 
- Updated `functions/api/ai.js` to use `performAutoRagSearch` for context retrieval so both `/api/search` and `/api/ai` share the same resilient AutoRAG behavior. 

### Testing
- Ran `npx eslint functions/api/_ai-search.js functions/api/search.js functions/api/ai.js` and it completed without errors. 
- Ran `npx prettier --check` and `npx prettier --write` on the new file and formatting checks passed. 
- Pre-commit checks via `lint-staged` (ESLint + Prettier) were executed as part of the local checks and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996b18044d0832d91eb457bd2057508)