### PR TITLE
fix: stabilize ai search and prevent 500 errors

### DIFF
--- a/functions/api/debug-rag.js
+++ b/functions/api/debug-rag.js
@@ -2,10 +2,13 @@ export async function onRequest(context) {
   const { env } = context;
 
   if (!env.AI) {
-    return new Response(JSON.stringify({ error: 'AI binding not configured' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({ error: 'AI binding not configured' }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
   }
 
   try {
@@ -22,25 +25,38 @@ export async function onRequest(context) {
 
     const duration = Date.now() - startTime;
 
-    return new Response(JSON.stringify({
-      status: 'ok',
-      ragId,
-      duration_ms: duration,
-      results_count: searchData?.data?.length || 0,
-      raw_response: searchData
-    }, null, 2), {
-      headers: { 'Content-Type': 'application/json' },
-    });
-
+    return new Response(
+      JSON.stringify(
+        {
+          status: 'ok',
+          ragId,
+          duration_ms: duration,
+          results_count: searchData?.data?.length || 0,
+          raw_response: searchData,
+        },
+        null,
+        2,
+      ),
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
   } catch (error) {
-    return new Response(JSON.stringify({
-      status: 'error',
-      message: error.message,
-      stack: error.stack,
-      ragId: env.RAG_ID || 'wispy-pond-1055'
-    }, null, 2), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify(
+        {
+          status: 'error',
+          message: error.message,
+          stack: error.stack,
+          ragId: env.RAG_ID || 'wispy-pond-1055',
+        },
+        null,
+        2,
+      ),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
   }
 }

--- a/functions/api/debug-rag.js
+++ b/functions/api/debug-rag.js
@@ -1,0 +1,46 @@
+export async function onRequest(context) {
+  const { env } = context;
+
+  if (!env.AI) {
+    return new Response(JSON.stringify({ error: 'AI binding not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const ragId = env.RAG_ID || 'wispy-pond-1055';
+    const startTime = Date.now();
+
+    // Minimal test call without complex params
+    const searchData = await env.AI.autorag(ragId).aiSearch({
+      query: 'test',
+      max_num_results: 1,
+      rewrite_query: false, // Match working chat config
+      stream: false,
+    });
+
+    const duration = Date.now() - startTime;
+
+    return new Response(JSON.stringify({
+      status: 'ok',
+      ragId,
+      duration_ms: duration,
+      results_count: searchData?.data?.length || 0,
+      raw_response: searchData
+    }, null, 2), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+  } catch (error) {
+    return new Response(JSON.stringify({
+      status: 'error',
+      message: error.message,
+      stack: error.stack,
+      ragId: env.RAG_ID || 'wispy-pond-1055'
+    }, null, 2), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/functions/api/search.js
+++ b/functions/api/search.js
@@ -71,15 +71,20 @@ export async function onRequestPost(context) {
 
     // Handle empty or invalid response gracefully
     if (!searchData || !searchData.data || !Array.isArray(searchData.data)) {
-        console.warn(`Search returned empty/invalid data for query: "${query}" (Time: ${duration}ms)`);
-        return new Response(JSON.stringify({
-            results: [],
-            summary: `Keine Ergebnisse für "${query}" gefunden.`,
-            count: 0,
-            query: query,
-        }), {
-            headers: corsHeaders,
-        });
+      console.warn(
+        `Search returned empty/invalid data for query: "${query}" (Time: ${duration}ms)`,
+      );
+      return new Response(
+        JSON.stringify({
+          results: [],
+          summary: `Keine Ergebnisse für "${query}" gefunden.`,
+          count: 0,
+          query: query,
+        }),
+        {
+          headers: corsHeaders,
+        },
+      );
     }
 
     // Transform AI Search Beta response to our format
@@ -160,8 +165,8 @@ export async function onRequestPost(context) {
     });
 
     const summaryText = searchData.response
-        ? searchData.response.trim().substring(0, 150)
-        : `${finalResults.length} ${finalResults.length === 1 ? 'Ergebnis' : 'Ergebnisse'} für "${query}"`;
+      ? searchData.response.trim().substring(0, 150)
+      : `${finalResults.length} ${finalResults.length === 1 ? 'Ergebnis' : 'Ergebnisse'} für "${query}"`;
 
     const responseData = {
       results: finalResults,


### PR DESCRIPTION
This PR addresses the "Search currently unavailable" error by aligning the `search.js` configuration with the working `ai.js` logic (disabling query rewriting and removing system prompt). It also adds a public debug endpoint to verify RAG index connectivity.

---
*PR created automatically by Jules for task [11260558365048431858](https://jules.google.com/task/11260558365048431858) started by @aKs030*