### PR TITLE
🔒 Fix insecure CORS configuration

### DIFF
--- a/functions/api/_cors.js
+++ b/functions/api/_cors.js
@@ -1,7 +1,7 @@
 /**
  * Shared CORS Utility for Cloudflare Pages Functions
  * Centralizes origin validation and header management.
- * @version 1.0.1
+ * @version 1.0.2
  * Verified existence for deployment: Feb 14, 2026
  */
 
@@ -29,11 +29,22 @@ export function getCorsHeaders(request, env) {
 
   // Only set CORS headers if the origin is in our whitelist or is a preview/local environment
   if (origin) {
-    const isAllowed =
-      allowedOrigins.includes(origin) ||
-      origin.endsWith('.pages.dev') || // Allow all Pages Preview URLs
-      origin.includes('localhost') || // Allow local development
-      origin.includes('127.0.0.1'); // Allow local development IP
+    let isAllowed = allowedOrigins.includes(origin);
+
+    // Securely check for Cloudflare Pages preview URLs (strictly *.1web.pages.dev)
+    if (!isAllowed) {
+      // Regex allows https://1web.pages.dev and https://<branch>.1web.pages.dev
+      const isPreview = /^https:\/\/(?:[a-z0-9-]+\.)*1web\.pages\.dev$/.test(
+        origin,
+      );
+      if (isPreview) isAllowed = true;
+    }
+
+    // Securely check for local development (http://localhost or http://127.0.0.1 with optional port)
+    if (!isAllowed) {
+      const isLocal = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+      if (isLocal) isAllowed = true;
+    }
 
     if (isAllowed) {
       headers['Access-Control-Allow-Origin'] = origin;

--- a/functions/api/_cors.test.js
+++ b/functions/api/_cors.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getCorsHeaders } from './_cors.js';
+
+test('getCorsHeaders security check', async (t) => {
+  const env = {
+    ALLOWED_ORIGINS:
+      'https://abdulkerimsesli.de,https://www.abdulkerimsesli.de',
+  };
+
+  const allowedOrigins = [
+    'https://abdulkerimsesli.de',
+    'https://www.abdulkerimsesli.de',
+    'https://1web.pages.dev',
+    'https://preview-branch.1web.pages.dev',
+    'http://localhost:8788',
+    'http://127.0.0.1:8788',
+  ];
+
+  const deniedOrigins = [
+    'https://evil.com',
+    'https://evil-site.pages.dev',
+    'https://evil.com/localhost',
+    'http://evil.com/127.0.0.1',
+    'https://not-1web.pages.dev',
+  ];
+
+  await t.test('allows valid origins', () => {
+    for (const origin of allowedOrigins) {
+      const req = new Request('https://api.example.com', {
+        headers: { Origin: origin },
+      });
+      const headers = getCorsHeaders(req, env);
+      assert.equal(
+        headers['Access-Control-Allow-Origin'],
+        origin,
+        `Origin ${origin} should be allowed`,
+      );
+    }
+  });
+
+  await t.test('denies invalid origins', () => {
+    for (const origin of deniedOrigins) {
+      const req = new Request('https://api.example.com', {
+        headers: { Origin: origin },
+      });
+      const headers = getCorsHeaders(req, env);
+      assert.equal(
+        headers['Access-Control-Allow-Origin'],
+        undefined,
+        `Origin ${origin} should be denied`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
**What:** Fixed a security vulnerability in `functions/api/_cors.js` where the CORS configuration was too permissive.
**Risk:** The previous implementation allowed any origin ending in `.pages.dev` (including malicious ones like `evil-site.pages.dev`) and any origin containing "localhost" or "127.0.0.1" (e.g., `evil.com/localhost`) to access the API. This could allow attackers to bypass CORS restrictions.
**Solution:**
- Implemented strict Regex-based validation for origins.
- Production: Only allows origins listed in `ALLOWED_ORIGINS` (env var).
- Preview: Strictly matches `https://1web.pages.dev` or `https://*.1web.pages.dev` (subdomains).
- Local: Strictly matches `http://localhost` or `http://127.0.0.1` with an optional port.
- Added a reproduction and verification test suite in `functions/api/_cors.test.js`.

---
*PR created automatically by Jules for task [14366682907821812215](https://jules.google.com/task/14366682907821812215) started by @aKs030*