### PR TITLE
🧹 Add htm to global import map and refactor usages

### DIFF
--- a/content/components/icons/icons.js
+++ b/content/components/icons/icons.js
@@ -1,4 +1,4 @@
-import htm from 'https://esm.sh/htm@3.1.1';
+import htm from 'htm';
 import React from 'react';
 
 const html = htm.bind(React.createElement);

--- a/content/templates/base-head.html
+++ b/content/templates/base-head.html
@@ -7,7 +7,8 @@
       "react-dom": "https://esm.sh/react-dom@19.2.4",
       "react-dom/client": "https://esm.sh/react-dom@19.2.4/client",
       "three": "https://cdn.jsdelivr.net/npm/three@0.183.1/build/three.module.min.js",
-      "dompurify": "https://esm.sh/dompurify@3.3.1"
+      "dompurify": "https://esm.sh/dompurify@3.3.1",
+      "htm": "https://esm.sh/htm@3.1.1"
     },
     "scopes": {
       "https://esm.sh/": {

--- a/pages/blog/blog-app.js
+++ b/pages/blog/blog-app.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import htm from 'https://esm.sh/htm@3.1.1';
+import htm from 'htm';
 import { createLogger } from '/content/core/logger.js';
 import { createUseTranslation } from '/content/core/utils.js';
 import { AppLoadManager } from '/content/core/load-manager.js';

--- a/pages/blog/components/BlogComponents.js
+++ b/pages/blog/components/BlogComponents.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import htm from 'https://esm.sh/htm@3.1.1';
+import htm from 'htm';
 import { ArrowUp } from '/content/components/icons/icons.js';
 
 const html = htm.bind(React.createElement);


### PR DESCRIPTION
* 🎯 **What:** Added `htm` to the centralized import map in `content/templates/base-head.html` and updated `pages/blog/blog-app.js`, `pages/blog/components/BlogComponents.js`, and `content/components/icons/icons.js` to use the bare specifier.
* 💡 **Why:** To improve code health, consistency, and maintainability by centralizing dependency management. This aligns with the project's architecture and avoids multiple import map conflicts.
* ✅ **Verification:** Ran `npm run check` (linting, formatting). Verified that no `htm` URL imports remain in the modified files.
* ✨ **Result:** Cleaner imports and centralized management for `htm`.

---
*PR created automatically by Jules for task [4645284704274671401](https://jules.google.com/task/4645284704274671401) started by @aKs030*