### PR TITLE
Fix scroll jump and reduce code by removing scroll-snap and hacks

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -1,6 +1,6 @@
 /**
  * Main Application Entry Point
- * @version 6.2.0
+ * @version 6.2.1
  * @last-modified 2026-02-11
  */
 
@@ -65,12 +65,6 @@ const _initApp = () => {
     return;
   }
   _appInitialized = true;
-
-  // Scroll to top on init (Safari compatibility) - only if no hash in URL
-  if (!window.location.hash) {
-    window.scrollTo(0, 0);
-    appTimers.setTimeout(() => window.scrollTo(0, 0), 100);
-  }
 
   sectionManager.init();
 
@@ -200,11 +194,6 @@ globalThis.addEventListener('pageshow', (event) => {
     // Trigger visibility change to resume animations
     if (!document.hidden) {
       document.dispatchEvent(new CustomEvent('visibilitychange'));
-    }
-
-    // Force scroll to top on restoration - only if no hash in URL
-    if (!window.location.hash) {
-      window.scrollTo(0, 0);
     }
   }
 });

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -192,10 +192,6 @@ html {
   scroll-behavior: smooth;
 }
 
-.snap-page {
-  scroll-snap-type: y mandatory;
-}
-
 body {
   width: 100%;
   overflow-x: hidden;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de" class="snap-page">
+<html lang="de">
   <head>
     <!-- INJECT:BASE-HEAD -->
     <title>


### PR DESCRIPTION
Removed `scroll-snap-type: y mandatory` from `main.css` and the `snap-page` class from `index.html`. This was causing the page to "jump" to sections on load. Also removed `window.scrollTo(0,0)` hacks in `content/main.js` as requested to stop forcing scroll position. This simplifies the codebase and fixes the reported issue.

---
*PR created automatically by Jules for task [415003507167610201](https://jules.google.com/task/415003507167610201) started by @aKs030*