### PR TITLE
Prevent automatic scroll restoration on page reload

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -20,11 +20,6 @@ import { GlobalEventHandlers } from './core/events.js';
 const log = createLogger('main');
 const appTimers = new TimerManager('Main');
 
-// Prevent browser scroll restoration from reopening the page at old positions
-if ('scrollRestoration' in window.history) {
-  window.history.scrollRestoration = 'manual';
-}
-
 // Persistent storage request removed to avoid deprecation warnings
 
 // ===== Configuration & Environment =====

--- a/content/main.js
+++ b/content/main.js
@@ -20,6 +20,11 @@ import { GlobalEventHandlers } from './core/events.js';
 const log = createLogger('main');
 const appTimers = new TimerManager('Main');
 
+// Prevent browser scroll restoration from reopening the page at old positions
+if ('scrollRestoration' in window.history) {
+  window.history.scrollRestoration = 'manual';
+}
+
 // Persistent storage request removed to avoid deprecation warnings
 
 // ===== Configuration & Environment =====

--- a/content/templates/base-head.html
+++ b/content/templates/base-head.html
@@ -19,6 +19,13 @@
   }
 </script>
 
+<!-- Prevent native scroll restoration as early as possible -->
+<script>
+  if ('scrollRestoration' in window.history) {
+    window.history.scrollRestoration = 'manual';
+  }
+</script>
+
 <!-- Critical CSS - Loaded immediately to prevent FOUC -->
 <link rel="stylesheet" href="/content/styles/root.css" />
 <link rel="stylesheet" href="/content/styles/main.css" />


### PR DESCRIPTION
### Motivation
- Beim Neuladen wurde die Seite gelegentlich an einer früheren Scroll-Position (z. B. unten) geöffnet; das Ziel ist, die automatische Browser-Wiederherstellung der Scrollposition zu unterbinden und stattdessen das bestehende App-Verhalten für das Zurücksetzen der Position zu verwenden.

### Description
- Setze `window.history.scrollRestoration = 'manual'` in `content/main.js` (nur wenn unterstützt), sodass die App die Scrollposition manuell kontrolliert und das vorhandene `window.scrollTo(0, 0)` weiterhin die Quelle der Wahrheit bleibt.

### Testing
- Ausgeführt: `npx eslint content/main.js`, das Linting lief erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eacf94068832d912b40fdb1a0ff8e)