### PR TITLE
refactor: optimize scroll system and remove safari hack

### DIFF
--- a/content/core/view-transitions.js
+++ b/content/core/view-transitions.js
@@ -45,6 +45,19 @@ function applyPage(url, { title, mainHtml, bodyClass }) {
   document.title = title;
   if (bodyClass) document.body.className = bodyClass;
 
+  // Toggle .snap-page class on html based on URL path
+  try {
+    const urlObj = new URL(url, location.origin);
+    const isHome = urlObj.pathname === '/' || urlObj.pathname === '/index.html';
+    if (isHome) {
+      document.documentElement.classList.add('snap-page');
+    } else {
+      document.documentElement.classList.remove('snap-page');
+    }
+  } catch (e) {
+    console.warn('[ViewTransitions] Error parsing URL:', e);
+  }
+
   // Update canonical URL
   const canonical = document.querySelector('link[rel="canonical"]');
   if (canonical) canonical.href = url;

--- a/content/main.js
+++ b/content/main.js
@@ -67,10 +67,12 @@ const _initApp = () => {
   _appInitialized = true;
 
   // Ensure correct initial state for snap-page class
-  const isHome = window.location.pathname === '/' || window.location.pathname === '/index.html';
+  const isHome =
+    window.location.pathname === '/' ||
+    window.location.pathname === '/index.html';
   if (isHome) {
     if (!document.documentElement.classList.contains('snap-page')) {
-       document.documentElement.classList.add('snap-page');
+      document.documentElement.classList.add('snap-page');
     }
   } else {
     document.documentElement.classList.remove('snap-page');
@@ -217,7 +219,10 @@ globalThis.addEventListener('pageshow', (event) => {
     }
 
     // Force scroll to top on restoration - only if no hash in URL and on snap page
-    if (document.documentElement.classList.contains('snap-page') && !window.location.hash) {
+    if (
+      document.documentElement.classList.contains('snap-page') &&
+      !window.location.hash
+    ) {
       window.scrollTo(0, 0);
     }
   }

--- a/content/main.js
+++ b/content/main.js
@@ -66,10 +66,24 @@ const _initApp = () => {
   }
   _appInitialized = true;
 
-  // Scroll to top on init (Safari compatibility) - only if no hash in URL
-  if (!window.location.hash) {
-    window.scrollTo(0, 0);
-    appTimers.setTimeout(() => window.scrollTo(0, 0), 100);
+  // Ensure correct initial state for snap-page class
+  const isHome = window.location.pathname === '/' || window.location.pathname === '/index.html';
+  if (isHome) {
+    if (!document.documentElement.classList.contains('snap-page')) {
+       document.documentElement.classList.add('snap-page');
+    }
+  } else {
+    document.documentElement.classList.remove('snap-page');
+  }
+
+  // Configure scroll restoration
+  if ('scrollRestoration' in history) {
+    if (document.documentElement.classList.contains('snap-page')) {
+      history.scrollRestoration = 'manual';
+      if (!window.location.hash) window.scrollTo(0, 0);
+    } else {
+      history.scrollRestoration = 'auto';
+    }
   }
 
   sectionManager.init();
@@ -202,8 +216,8 @@ globalThis.addEventListener('pageshow', (event) => {
       document.dispatchEvent(new CustomEvent('visibilitychange'));
     }
 
-    // Force scroll to top on restoration - only if no hash in URL
-    if (!window.location.hash) {
+    // Force scroll to top on restoration - only if no hash in URL and on snap page
+    if (document.documentElement.classList.contains('snap-page') && !window.location.hash) {
       window.scrollTo(0, 0);
     }
   }

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -151,10 +151,7 @@ main {
   );
 }
 
-.section {
-  scroll-snap-align: start;
-  scroll-snap-stop: always;
-  min-height: calc(
+.section {min-height: calc(
     100vh - var(--content-top-offset) - var(--content-bottom-offset)
   );
   height: calc(
@@ -562,3 +559,9 @@ a:hover {
 }
 
 /* ===== END PRINT STYLES ===== */
+
+/* Scroll snap only for the home page */
+.snap-page .section {
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+}

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -151,7 +151,8 @@ main {
   );
 }
 
-.section {min-height: calc(
+.section {
+  min-height: calc(
     100vh - var(--content-top-offset) - var(--content-bottom-offset)
   );
   height: calc(


### PR DESCRIPTION
This PR addresses issues with the scroll system, particularly removing a Safari-specific hack and cleaning up the scroll-snap implementation.

**Key Changes:**

1.  **CSS Cleanup (`content/styles/main.css`):**
    -   The `scroll-snap` properties on `.section` are now scoped to `.snap-page .section`. This means scroll snapping will only occur when the parent (the `<html>` element) has the `snap-page` class.
    -   This resolves issues where scroll snapping might inadvertently apply to other pages or interfere with normal scrolling.

2.  **JS Refactoring (`content/main.js`):**
    -   Removed the `setTimeout(() => window.scrollTo(0, 0), 100)` hack that was originally added for Safari compatibility. This removes a visible jump on page load.
    -   Implemented logic to control `history.scrollRestoration`.
        -   On the home page (detected by the `.snap-page` class), restoration is set to `'manual'` to ensure the user always starts at the top of the "snap experience".
        -   On other pages, it is set to `'auto'`, allowing the browser to restore the previous scroll position naturally on back/forward navigation or reload.
    -   Added an initial check on page load to add the `.snap-page` class if the current path is `/` or `/index.html`, ensuring the correct initial state.

3.  **Dynamic Class Handling (`content/core/view-transitions.js`):**
    -   Updated the navigation logic to dynamically add or remove the `.snap-page` class on the `<html>` element when navigating between pages. This ensures that if a user navigates from the home page to a content page (or vice-versa) via client-side routing, the scroll behavior updates immediately without a full reload.

These changes result in a cleaner, more native-feeling scroll experience across browsers and fix the reported "jumpiness" and unwanted snapping behavior.

---
*PR created automatically by Jules for task [14927665978648132125](https://jules.google.com/task/14927665978648132125) started by @aKs030*