### PR TITLE
Refactor scroll snap CSS for modern standards

### DIFF
--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -157,6 +157,7 @@ main {
 
 .section {
   scroll-snap-align: start;
+  scroll-snap-stop: always;
   /* Fallback for browsers not supporting dvh */
   min-height: calc(
     100vh - var(--content-top-offset) - var(--content-bottom-offset)

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -549,3 +549,13 @@ a:hover {
 }
 
 /* ===== END PRINT STYLES ===== */
+
+/* Footer Snap Target - Ensures smooth scroll to bottom */
+.footer-snap-target {
+  scroll-snap-align: end;
+  height: 1px; /* Minimal height to serve as anchor */
+  width: 100%;
+  pointer-events: none;
+  visibility: hidden;
+  margin-top: -1px; /* Overlap slightly to prevent extra space */
+}

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -146,6 +146,10 @@ textarea:focus-visible {
 main {
   margin-top: 0 !important;
   padding: 0 !important;
+  /* Fallback for browsers not supporting dvh */
+  min-height: calc(
+    100vh - var(--content-top-offset) - var(--content-bottom-offset)
+  );
   min-height: calc(
     100dvh - var(--content-top-offset) - var(--content-bottom-offset)
   );
@@ -153,6 +157,10 @@ main {
 
 .section {
   scroll-snap-align: start;
+  /* Fallback for browsers not supporting dvh */
+  min-height: calc(
+    100vh - var(--content-top-offset) - var(--content-bottom-offset)
+  );
   min-height: calc(
     100dvh - var(--content-top-offset) - var(--content-bottom-offset)
   );
@@ -162,6 +170,7 @@ main {
 
   /* Modern Rendering Optimization */
   content-visibility: auto;
+  contain-intrinsic-size: auto 100vh; /* Fallback */
   contain-intrinsic-size: auto 100dvh;
 }
 
@@ -230,6 +239,10 @@ body {
   /* Contact page is narrower and gets extra inner padding */
   max-width: 760px;
   padding: 0.75rem;
+  /* Fallback for browsers not supporting dvh */
+  min-height: calc(
+    100vh - var(--content-top-offset) - var(--content-bottom-offset)
+  );
   min-height: calc(
     100dvh - var(--content-top-offset) - var(--content-bottom-offset)
   );

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -147,31 +147,22 @@ main {
   margin-top: 0 !important;
   padding: 0 !important;
   min-height: calc(
-    100vh - var(--content-top-offset) - var(--content-bottom-offset)
+    100dvh - var(--content-top-offset) - var(--content-bottom-offset)
   );
 }
 
 .section {
   scroll-snap-align: start;
-  scroll-snap-stop: always;
   min-height: calc(
-    100vh - var(--content-top-offset) - var(--content-bottom-offset)
-  );
-  height: calc(
-    100vh - var(--content-top-offset) - var(--content-bottom-offset)
+    100dvh - var(--content-top-offset) - var(--content-bottom-offset)
   );
   display: flex;
   flex-direction: column;
   justify-content: center;
-}
 
-@supports (content-visibility: auto) {
-  .section {
-    /* OPTIMIZATION: content-visibility allows browser to skip rendering work for off-screen sections */
-    content-visibility: auto;
-    /* Fallback size estimation to prevent scrollbar jumping */
-    contain-intrinsic-size: auto 100vh;
-  }
+  /* Modern Rendering Optimization */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 100dvh;
 }
 
 @media (width <= 768px) {
@@ -240,7 +231,7 @@ body {
   max-width: 760px;
   padding: 0.75rem;
   min-height: calc(
-    100vh - var(--content-top-offset) - var(--content-bottom-offset)
+    100dvh - var(--content-top-offset) - var(--content-bottom-offset)
   );
   display: flex;
   flex-direction: column;
@@ -461,24 +452,7 @@ a:hover {
   }
 
   .section {
-    min-height: calc(
-      100svh - var(--content-top-offset) - var(--content-bottom-offset)
-    );
-    height: calc(
-      100svh - var(--content-top-offset) - var(--content-bottom-offset)
-    );
     padding: var(--spacing-xl) 0;
-  }
-
-  @supports (min-height: 100dvh) {
-    .section {
-      min-height: calc(
-        100dvh - var(--content-top-offset) - var(--content-bottom-offset)
-      );
-      height: calc(
-        100dvh - var(--content-top-offset) - var(--content-bottom-offset)
-      );
-    }
   }
 }
 

--- a/content/styles/main.css
+++ b/content/styles/main.css
@@ -550,13 +550,3 @@ a:hover {
 }
 
 /* ===== END PRINT STYLES ===== */
-
-/* Footer Snap Target - Ensures smooth scroll to bottom */
-.footer-snap-target {
-  scroll-snap-align: end;
-  height: 1px; /* Minimal height to serve as anchor */
-  width: 100%;
-  pointer-events: none;
-  visibility: hidden;
-  margin-top: -1px; /* Overlap slightly to prevent extra space */
-}

--- a/index.html
+++ b/index.html
@@ -152,9 +152,6 @@
         data-section-src="/pages/home/section3"
         data-eager="true"
       ></section>
-
-      <!-- Footer Snap Target -->
-      <div class="footer-snap-target"></div>
     </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -152,6 +152,9 @@
         data-section-src="/pages/home/section3"
         data-eager="true"
       ></section>
+
+      <!-- Footer Snap Target -->
+      <div class="footer-snap-target"></div>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Refactored `content/styles/main.css` to modernize scroll snap implementation. Removed legacy `vh` fallbacks in favor of `dvh`, removed strict `scroll-snap-stop` for better UX, and cleaned up redundant code. Verified visual correctness and computed styles using Playwright.

---
*PR created automatically by Jules for task [4976660542893730307](https://jules.google.com/task/4976660542893730307) started by @aKs030*