### PR TITLE
feat: migrate ui to view transitions and container queries

### DIFF
--- a/content/components/menu/menu.css
+++ b/content/components/menu/menu.css
@@ -19,6 +19,8 @@
 
 /* ===== Custom Element Layout ===== */
 site-menu {
+  container-type: inline-size;
+  container-name: sitemenu;
   display: contents;
 }
 
@@ -176,7 +178,7 @@ site-menu {
   letter-spacing: -0.02em;
 }
 
-@media (width >= 901px) {
+@container sitemenu (width >= 901px) {
   .site-header {
     min-width: var(--menu-header-min-width-desktop);
   }
@@ -224,13 +226,13 @@ site-menu {
   display: inline-block;
 }
 
-@media (max-width: 1024px) {
+@container sitemenu (max-width: 1024px) {
   .site-subtitle {
     display: none !important;
   }
 }
 
-@media (max-width: 900px) {
+@container sitemenu (max-width: 900px) {
   .site-subtitle {
     display: inline-block !important;
     font-size: var(--size-r-0-875);
@@ -241,7 +243,7 @@ site-menu {
   }
 }
 
-@media (max-width: 480px) {
+@container sitemenu (max-width: 480px) {
   .site-title {
     font-size: var(--size-r-1);
   }
@@ -1033,7 +1035,7 @@ site-menu {
     transform: translateY(0);
   }
 }
-@media (width >= 901px) {
+@container sitemenu (width >= 901px) {
   .site-header.search-mode {
     justify-content: center;
     padding-inline: var(--size-16);
@@ -1250,7 +1252,7 @@ site-menu {
 }
 
 /* ===== Mobile Responsive ===== */
-@media (max-width: 900px) {
+@container sitemenu (max-width: 900px) {
   .site-header {
     display: flex;
     justify-content: space-between;
@@ -1562,7 +1564,7 @@ site-menu {
 }
 
 /* Extra Small Screens */
-@media (max-width: 480px) {
+@container sitemenu (max-width: 480px) {
   .site-header {
     width: calc(100% - var(--size-12) - var(--safe-left) - var(--safe-right));
     padding: 0 var(--size-12);
@@ -1618,4 +1620,13 @@ site-menu {
   .menu-search__desc {
     font-size: var(--size-11);
   }
+}
+
+/* View Transitions for Menu */
+::view-transition-group(menu) {
+  animation-duration: 0.3s;
+}
+
+.site-menu {
+  view-transition-name: menu;
 }

--- a/content/components/menu/modules/MenuRenderer.js
+++ b/content/components/menu/modules/MenuRenderer.js
@@ -4,6 +4,7 @@
 
 import { MenuTemplate } from './MenuTemplate.js';
 import { i18n } from '../../../core/i18n.js';
+import { withViewTransition } from '../../../core/view-transitions.js';
 
 /**
  * @typedef {import('./MenuState.js').MenuState} MenuState
@@ -78,14 +79,19 @@ export class MenuRenderer {
   setupStateSubscriptions() {
     // Open/Close State
     this.state.on('openChange', (isOpen) => {
-      const toggle = this.container.querySelector('.site-menu__toggle');
-      const menu = this.container.querySelector('.site-menu');
+      withViewTransition(
+        () => {
+          const toggle = this.container.querySelector('.site-menu__toggle');
+          const menu = this.container.querySelector('.site-menu');
 
-      if (menu) menu.classList.toggle('open', isOpen);
-      if (toggle) toggle.classList.toggle('active', isOpen);
+          if (menu) menu.classList.toggle('open', isOpen);
+          if (toggle) toggle.classList.toggle('active', isOpen);
 
-      // Accessibility update
-      if (toggle) toggle.setAttribute('aria-expanded', String(isOpen));
+          // Accessibility update
+          if (toggle) toggle.setAttribute('aria-expanded', String(isOpen));
+        },
+        { types: [isOpen ? 'menu-open' : 'menu-close'] },
+      );
     });
 
     // Active Link State

--- a/content/components/robot-companion/robot-companion.css
+++ b/content/components/robot-companion/robot-companion.css
@@ -1,5 +1,7 @@
 /* Container für den Roboter - fixiert unten rechts */
 #robot-companion-container {
+  container-type: inline-size;
+  container-name: robotcontainer;
   position: fixed;
   bottom: var(--size-30);
   right: var(--size-30);
@@ -1339,7 +1341,7 @@
   }
 }
 
-@media (width <= 480px) {
+@container robotcontainer (width <= 480px) {
   #robot-companion-container {
     bottom: var(--size-15);
     right: var(--size-15);
@@ -1369,7 +1371,7 @@
 }
 
 /* Mobile: Chat-Inhalte kompakter bei schmalen Viewports */
-@media (width <= 480px) {
+@container robotcontainer (width <= 480px) {
   .chat-messages {
     padding: var(--size-15);
   }
@@ -1479,7 +1481,7 @@
 
 /* Mobile Optimization: Prevent iOS Zoom on Input Focus */
 /* Mobile: input font-size für iOS Zoom-Prevention */
-@media (width <= 480px) {
+@container robotcontainer (width <= 480px) {
   #robot-chat-input {
     font-size: var(--size-16) !important;
   }


### PR DESCRIPTION
Replaced media queries with container queries in `robot-companion.css` and `menu.css` to allow these components to decouple from the global viewport and react appropriately based on their immediate container size.

Additionally, implemented the `withViewTransition` helper inside `MenuRenderer.js` `openChange` subscription to use View Transitions API when the menu toggles open and close. Also added a `view-transition-name` in the menu CSS to support the animation.

---
*PR created automatically by Jules for task [3534345161015060047](https://jules.google.com/task/3534345161015060047) started by @aKs030*