### PR TITLE
Remove PostalAddress schema

### DIFF
--- a/content/core/types.js
+++ b/content/core/types.js
@@ -25,21 +25,12 @@
  * @property {string[]} jobTitle - Job titles
  * @property {string} email - Contact email
  * @property {string} areaServed - Service area
- * @property {PostalAddress} address - Physical address
  * @property {GeoCoordinates} geo - Geographic coordinates
  * @property {string[]} sameAs - Social media URLs
  * @property {ContactPoint[]} contactPoint - Contact points
  * @property {string} telephone - Phone number
  * @property {string} [licensePage] - License page URL
  * @property {string} [copyrightHolder] - Copyright holder name
- */
-
-/**
- * @typedef {Object} PostalAddress
- * @property {string} streetAddress - Street address
- * @property {string} addressLocality - City
- * @property {string} postalCode - Postal code
- * @property {string} addressCountry - Country code
  */
 
 /**

--- a/pages/videos/videos.js
+++ b/pages/videos/videos.js
@@ -280,13 +280,6 @@ const renderVideoCard = (container, it, detailsMap, index = 0) => {
         copyrightNotice: `© ${new Date().getFullYear()} Abdulkerim Sesli`,
         acquireLicensePage: 'https://www.abdulkerimsesli.de/#image-license',
       },
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: 'Sterkrader Str. 59',
-        postalCode: '13507',
-        addressLocality: 'Berlin',
-        addressCountry: 'DE',
-      },
     },
   };
 


### PR DESCRIPTION
Removed the `PostalAddress` object (Sterkrader Str. 59, Berlin) and corresponding `address` properties from `pages/videos/videos.js` and `content/core/types.js` to prevent search engines from incorrectly associating the business with a physical address, as it operates purely online.

---
*PR created automatically by Jules for task [11685474525560010878](https://jules.google.com/task/11685474525560010878) started by @aKs030*