### PR TITLE
⚡ Bolt: Optimize humanizeSlug performance with single-pass reduce

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2025-03-08 - Avoid Array Pipeline Allocations in Middleware
+
+**Learning:** Edge middleware functions execute on every incoming request. Using chained array methods like `.map().filter().map()` for string parsing (like in `humanizeSlug`) creates multiple intermediate array allocations. This increases memory usage and Garbage Collection (GC) pressure, slowing down the critical path.
+**Action:** Use a single-pass `.reduce()` or a standard loop for string segment transformations in edge environment utility functions to minimize intermediate memory allocations.

--- a/functions/_middleware-utils/route-seo.js
+++ b/functions/_middleware-utils/route-seo.js
@@ -40,9 +40,13 @@ function normalizeSlug(value) {
 function humanizeSlug(value) {
   return String(value || '')
     .split(/[-_]+/)
-    .map((segment) => segment.trim())
-    .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .reduce((acc, rawSegment) => {
+      const segment = rawSegment.trim();
+      if (segment) {
+        acc.push(segment.charAt(0).toUpperCase() + segment.slice(1));
+      }
+      return acc;
+    }, [])
     .join(' ');
 }
 


### PR DESCRIPTION
💡 What: Replaced a chained array method pipeline (`.map().filter().map()`) in the `humanizeSlug` function with a single `.reduce()` pass.
🎯 Why: Edge middleware functions execute on every incoming request. Using chained array methods for string parsing creates multiple intermediate array allocations. This increases memory usage and Garbage Collection (GC) pressure, slowing down the critical path.
📊 Impact: Reduces array allocations by ~66% per `humanizeSlug` call, leading to lower GC overhead and faster string processing in edge requests.
🔬 Measurement: Can be verified by running `npm run qa` to ensure no regressions, and profiling edge function memory/CPU usage under load to observe reduced GC spikes.

---
*PR created automatically by Jules for task [3730209169779359013](https://jules.google.com/task/3730209169779359013) started by @aKs030*