### PR TITLE
🎨 Palette: [Add aria-labelledby to cookie banner toggles]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-03-01 - [Accessible Custom Toggles in Cookie Banner]
+
+**Learning:** Custom toggle switches built with `<input type="checkbox">` and CSS often rely on adjacent `<label>` elements or sibling headings for visual context, but lack semantic connection for screen readers if `aria-labelledby` or `aria-describedby` isn't used. Specifically, the cookie setting toggles had headings describing the setting, but the inputs themselves had no accessible name.
+**Action:** When creating custom `<label>` based toggles where the descriptive text is outside the label itself, always ensure the `<input>` element uses `aria-labelledby` (pointing to the setting title ID) and `aria-describedby` (pointing to the setting description ID) to provide full context to screen reader users.

--- a/content/components/footer/footer.html
+++ b/content/components/footer/footer.html
@@ -229,26 +229,47 @@
 
         <div class="cookie-category">
           <div class="category-header">
-            <h3 data-i18n="footer.cookie_settings.analytics.title">Analyse</h3>
+            <h3
+              id="analytics-title"
+              data-i18n="footer.cookie_settings.analytics.title"
+            >
+              Analyse
+            </h3>
             <label class="toggle">
-              <input type="checkbox" id="analytics-toggle" checked />
+              <input
+                type="checkbox"
+                id="analytics-toggle"
+                checked
+                aria-labelledby="analytics-title"
+                aria-describedby="analytics-desc"
+              />
               <span class="slider"></span>
             </label>
           </div>
-          <p data-i18n="footer.cookie_settings.analytics.desc">
+          <p
+            id="analytics-desc"
+            data-i18n="footer.cookie_settings.analytics.desc"
+          >
             Hilft uns, Inhalte zu verbessern.
           </p>
         </div>
 
         <div class="cookie-category">
           <div class="category-header">
-            <h3 data-i18n="footer.cookie_settings.ads.title">Werbung</h3>
+            <h3 id="ads-title" data-i18n="footer.cookie_settings.ads.title">
+              Werbung
+            </h3>
             <label class="toggle">
-              <input type="checkbox" id="ads-toggle" />
+              <input
+                type="checkbox"
+                id="ads-toggle"
+                aria-labelledby="ads-title"
+                aria-describedby="ads-desc"
+              />
               <span class="slider"></span>
             </label>
           </div>
-          <p data-i18n="footer.cookie_settings.ads.desc">
+          <p id="ads-desc" data-i18n="footer.cookie_settings.ads.desc">
             Erlaubt personalisierte Anzeigen.
           </p>
         </div>


### PR DESCRIPTION
💡 **What**: Added `aria-labelledby` and `aria-describedby` attributes to the custom toggle switches in the footer cookie settings. 
🎯 **Why**: Custom toggle switches built with `<input type="checkbox">` and CSS often lack semantic connection to their descriptive text. By associating the inputs with their adjacent headings and descriptions, screen reader users now get full context about what each toggle controls.
♿ **Accessibility**: Improves screen reader experience by providing an accessible name and description for the custom toggle inputs.

---
*PR created automatically by Jules for task [11799396193822872864](https://jules.google.com/task/11799396193822872864) started by @aKs030*