### PR TITLE
fix: resolve Prettier config in sync-import-map script

### DIFF
--- a/content/config/import-map.generated.js
+++ b/content/config/import-map.generated.js
@@ -1,39 +1,39 @@
 export const IMPORT_MAP_VERSIONS = Object.freeze({
-  react: "19.2.4",
-  "react-dom": "19.2.4",
-  "lucide-react": "0.577.0",
-  three: "0.183.2",
-  htm: "3.1.1",
-  "idb-keyval": "6.2.1",
+  react: '19.2.4',
+  'react-dom': '19.2.4',
+  'lucide-react': '0.577.0',
+  three: '0.183.2',
+  htm: '3.1.1',
+  'idb-keyval': '6.2.1',
 });
 
 export const IMPORT_MAP = Object.freeze({
   imports: Object.freeze({
-    react: "https://esm.sh/react@19.2.4",
-    "react-dom": "https://esm.sh/react-dom@19.2.4",
-    "react-dom/client": "https://esm.sh/react-dom@19.2.4/client",
-    "lucide-react": "https://esm.sh/lucide-react@0.577.0",
+    react: 'https://esm.sh/react@19.2.4',
+    'react-dom': 'https://esm.sh/react-dom@19.2.4',
+    'react-dom/client': 'https://esm.sh/react-dom@19.2.4/client',
+    'lucide-react': 'https://esm.sh/lucide-react@0.577.0',
     three:
-      "https://cdn.jsdelivr.net/npm/three@0.183.2/build/three.module.min.js",
-    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.183.2/examples/jsm/",
-    htm: "https://esm.sh/htm@3.1.1",
-    "idb-keyval": "https://esm.sh/idb-keyval@6.2.1",
-    "#core/": "/content/core/",
-    "#components/": "/content/components/",
-    "#config/": "/content/config/",
-    "#pages/": "/pages/",
+      'https://cdn.jsdelivr.net/npm/three@0.183.2/build/three.module.min.js',
+    'three/addons/': 'https://cdn.jsdelivr.net/npm/three@0.183.2/examples/jsm/',
+    htm: 'https://esm.sh/htm@3.1.1',
+    'idb-keyval': 'https://esm.sh/idb-keyval@6.2.1',
+    '#core/': '/content/core/',
+    '#components/': '/content/components/',
+    '#config/': '/content/config/',
+    '#pages/': '/pages/',
   }),
   scopes: Object.freeze({
-    "https://esm.sh/": Object.freeze({
-      react: "https://esm.sh/react@19.2.4",
+    'https://esm.sh/': Object.freeze({
+      react: 'https://esm.sh/react@19.2.4',
     }),
   }),
 });
 
 export const SEARCH_PRELOAD_IMPORT_KEYS = Object.freeze([
-  "htm",
-  "react-dom",
-  "react-dom/client",
+  'htm',
+  'react-dom',
+  'react-dom/client',
 ]);
 
 export const SEARCH_PRELOAD_URLS = Object.freeze(

--- a/content/templates/global-head.html
+++ b/content/templates/global-head.html
@@ -74,26 +74,26 @@
   try {
     var d = document.documentElement,
       s = window.localStorage,
-      c = s ? s.getItem("iweb-theme-preference") : null,
-      m = window.matchMedia("(prefers-color-scheme: light)").matches,
+      c = s ? s.getItem('iweb-theme-preference') : null,
+      m = window.matchMedia('(prefers-color-scheme: light)').matches,
       t =
-        d.getAttribute("data-force-theme") ||
-        (c === "light" || c === "dark" ? c : m ? "light" : "dark");
-    d.setAttribute("data-theme", t);
+        d.getAttribute('data-force-theme') ||
+        (c === 'light' || c === 'dark' ? c : m ? 'light' : 'dark');
+    d.setAttribute('data-theme', t);
     d.style.colorScheme = t;
     var metas = document.querySelectorAll('meta[name="theme-color"]');
     for (var i = 0; i < metas.length; i++) {
       var meta = metas[i];
-      if (meta.getAttribute("media")) {
+      if (meta.getAttribute('media')) {
         meta.setAttribute(
-          "media",
-          (meta.getAttribute("content") || "").toLowerCase() === "#ffffff"
-            ? t === "light"
-              ? "all"
-              : "not all"
-            : t === "dark"
-              ? "all"
-              : "not all",
+          'media',
+          (meta.getAttribute('content') || '').toLowerCase() === '#ffffff'
+            ? t === 'light'
+              ? 'all'
+              : 'not all'
+            : t === 'dark'
+              ? 'all'
+              : 'not all',
         );
       }
     }

--- a/scripts/sync-import-map.mjs
+++ b/scripts/sync-import-map.mjs
@@ -112,10 +112,14 @@ const currentGeneratedConfig = await readFile(
   generatedConfigPath,
   'utf8',
 ).catch(() => '');
+
+const prettierConfigPath = path.join(cwd, 'config/.prettierrc.json');
+const prettierConfig = JSON.parse(await readFile(prettierConfigPath, 'utf8'));
+
 const generatedConfigFormatOptions =
-  (await prettier.resolveConfig(generatedConfigPath)) || {};
+  (await prettier.resolveConfig(generatedConfigPath)) || prettierConfig;
 const templateFormatOptions =
-  (await prettier.resolveConfig(templatePath)) || {};
+  (await prettier.resolveConfig(templatePath)) || prettierConfig;
 const generatedConfigSource = await prettier.format(rawGeneratedConfigSource, {
   ...generatedConfigFormatOptions,
   filepath: generatedConfigPath,


### PR DESCRIPTION
Fixes a bug causing the `check:importmap` CI workflow task to fail due to formatting mismatches. The `scripts/sync-import-map.mjs` script was formatting the updated import maps with default Prettier settings rather than the ones specified in `config/.prettierrc.json`. This PR explicitly resolves the configuration so the output of `sync` matches `npm run lint:format`.

---
*PR created automatically by Jules for task [17705366354121323576](https://jules.google.com/task/17705366354121323576) started by @aKs030*