### PR TITLE
fix: remove forced scroll-to-top logic

### DIFF
--- a/content/components/menu/modules/MenuEvents.js
+++ b/content/components/menu/modules/MenuEvents.js
@@ -341,11 +341,6 @@ export class MenuEvents {
   }
 
   handleUrlChange() {
-    // make sure any navigation that lands here without a hash resets scroll
-    import('../../../core/utils.js').then(({ scrollTopIfNoHash }) => {
-      scrollTopIfNoHash();
-    });
-
     this.calculateAndSetActiveLink();
     this.updateTitleFromPathOrSection();
   }

--- a/content/core/utils.js
+++ b/content/core/utils.js
@@ -18,19 +18,6 @@ const log = createLogger('Utils');
 // ---------------------------------------------------------------------------
 
 /**
- * If the current location has no hash, scrolls to the top immediately and
- * schedules a second try after a brief delay. Used on initial load and when
- * restoring from bfcache to avoid Safari oddities.
- */
-export function scrollTopIfNoHash() {
-  if (!window.location.hash) {
-    window.scrollTo(0, 0);
-    // some browsers (mobile Safari) require a second call after render
-    setTimeout(() => window.scrollTo(0, 0), 100);
-  }
-}
-
-/**
  * When navigating with the View Transitions API we intercept same-page
  * navigations. This helper determines if a URL points to the same origin
  * and path as the current location, and -- if there is no hash -- performs a

--- a/content/main.js
+++ b/content/main.js
@@ -10,7 +10,7 @@ import { SectionManager } from '#core/section-manager.js';
 import { AppLoadManager, loadSignals } from '#core/load-manager.js';
 import { signal, effect, computed } from '#core/signals.js';
 import { ThreeEarthManager } from '#core/three-earth-manager.js';
-import { onDOMReady, TimerManager, scrollTopIfNoHash } from '#core/utils.js';
+import { onDOMReady, TimerManager } from '#core/utils.js';
 import { initViewTransitions } from '#core/view-transitions.js';
 import { i18n } from '#core/i18n.js';
 import { GlobalEventHandlers } from '#core/events.js';
@@ -77,9 +77,6 @@ const _initApp = () => {
     return;
   }
   _appInitialized = true;
-
-  // Ensure consistent scroll behaviour across browsers
-  scrollTopIfNoHash();
 
   sectionManager.init();
 
@@ -195,9 +192,6 @@ globalThis.addEventListener('pageshow', (event) => {
     if (!document.hidden) {
       document.dispatchEvent(new CustomEvent('visibilitychange'));
     }
-
-    // Force scroll to top on restoration - only if no hash in URL
-    scrollTopIfNoHash();
   }
 });
 


### PR DESCRIPTION
Fixes an issue where the page would automatically scroll to the top after a brief delay when loading or navigating without a hash. This was due to `scrollTopIfNoHash()` utilizing a `setTimeout(..., 100)` logic. Cleanly removed all declarations and calls.

---
*PR created automatically by Jules for task [11831627346006560964](https://jules.google.com/task/11831627346006560964) started by @aKs030*