### PR TITLE
🧹 [Code Health] Remove unused export `detectSchemaPageType`

### DIFF
--- a/content/core/schema-page-types.js
+++ b/content/core/schema-page-types.js
@@ -182,7 +182,7 @@ const BASE_SEO_KEYWORDS = Object.freeze([
 const SCHEMA_TITLE_SPLIT_RE = /[\s|,–—:/]+/;
 const SEO_TITLE_SPLIT_RE = /[\s,.;:/()[\]|!?-]+/;
 
-export function detectSchemaPageType(pathname = '/') {
+function detectSchemaPageType(pathname = '/') {
   const path = String(pathname || '/').toLowerCase();
 
   if (path === '/' || path === '' || path === '/index.html') return 'home';


### PR DESCRIPTION
🎯 **What:** Removed the `export` keyword from `detectSchemaPageType` in `content/core/schema-page-types.js`.
💡 **Why:** `detectSchemaPageType` is only used internally by `getSchemaPageTypeConfig` within the same file. Making it a private module function cleans up the public API surface area of the file and slightly reduces bundle size.
✅ **Verification:** Ran `npm run qa` locally to ensure formatting, structure checking, linting, and docs are all intact. Reviewed usages across the repo using `grep` to confirm there were no external usages.
✨ **Result:** Improved module encapsulation without altering existing site behavior.

---
*PR created automatically by Jules for task [634097830321663115](https://jules.google.com/task/634097830321663115) started by @aKs030*