### PR TITLE
perf(ai-agent): enforce timeouts and parallelize memory operations

### DIFF
--- a/functions/api/_content-rag.js
+++ b/functions/api/_content-rag.js
@@ -1,10 +1,10 @@
-import { loadYouTubeVideos } from "./_sitemap-data.js";
+import { loadYouTubeVideos } from './_sitemap-data.js';
 
-const BLOG_INDEX_PATH = "/pages/blog/posts/index.json";
-const PROJECTS_INDEX_PATH = "/pages/projekte/apps-config.json";
-const ABOUT_PAGE_PATH = "/pages/about/index.html";
-const CONTENT_RAG_MANIFEST_KEY = "robot-content-rag:manifest:v1";
-const CONTENT_RAG_SEARCH_INDEX_KEY = "robot-content-rag:search-index:v1";
+const BLOG_INDEX_PATH = '/pages/blog/posts/index.json';
+const PROJECTS_INDEX_PATH = '/pages/projekte/apps-config.json';
+const ABOUT_PAGE_PATH = '/pages/about/index.html';
+const CONTENT_RAG_MANIFEST_KEY = 'robot-content-rag:manifest:v1';
+const CONTENT_RAG_SEARCH_INDEX_KEY = 'robot-content-rag:search-index:v1';
 const DEFAULT_TOP_K = 4;
 const DEFAULT_SCORE_THRESHOLD = 0.25;
 const DEFAULT_CHUNK_MAX_CHARS = 900;
@@ -19,80 +19,80 @@ const MAX_RERANKED_MATCHES = 12;
 const MAX_SOURCE_LINKS = 2;
 const CONTENT_RAG_MANIFEST_VERSION = 3;
 const QUERY_STOP_WORDS = new Set([
-  "aber",
-  "abdulkerim",
-  "about",
-  "agent",
-  "ai",
-  "als",
-  "am",
-  "an",
-  "and",
-  "antwort",
-  "antwortet",
-  "auf",
-  "aus",
-  "bei",
-  "beim",
-  "ber",
-  "bitte",
-  "blog",
-  "companion",
-  "das",
-  "dein",
-  "deine",
-  "dem",
-  "den",
-  "der",
-  "des",
-  "die",
-  "du",
-  "ein",
-  "eine",
-  "einer",
-  "eines",
-  "er",
-  "es",
-  "for",
-  "fragt",
-  "frage",
-  "geht",
-  "hat",
-  "how",
-  "ich",
-  "im",
-  "in",
-  "ist",
-  "kerim",
-  "mein",
-  "meint",
-  "mit",
-  "oder",
-  "portfolio",
-  "robot",
-  "seine",
-  "seinen",
-  "sesli",
-  "sie",
-  "sieht",
-  "site",
-  "the",
-  "uber",
-  "ueber",
-  "und",
-  "von",
-  "was",
-  "website",
-  "wie",
-  "wir",
-  "wo",
-  "zu",
-  "zum",
-  "zur",
+  'aber',
+  'abdulkerim',
+  'about',
+  'agent',
+  'ai',
+  'als',
+  'am',
+  'an',
+  'and',
+  'antwort',
+  'antwortet',
+  'auf',
+  'aus',
+  'bei',
+  'beim',
+  'ber',
+  'bitte',
+  'blog',
+  'companion',
+  'das',
+  'dein',
+  'deine',
+  'dem',
+  'den',
+  'der',
+  'des',
+  'die',
+  'du',
+  'ein',
+  'eine',
+  'einer',
+  'eines',
+  'er',
+  'es',
+  'for',
+  'fragt',
+  'frage',
+  'geht',
+  'hat',
+  'how',
+  'ich',
+  'im',
+  'in',
+  'ist',
+  'kerim',
+  'mein',
+  'meint',
+  'mit',
+  'oder',
+  'portfolio',
+  'robot',
+  'seine',
+  'seinen',
+  'sesli',
+  'sie',
+  'sieht',
+  'site',
+  'the',
+  'uber',
+  'ueber',
+  'und',
+  'von',
+  'was',
+  'website',
+  'wie',
+  'wir',
+  'wo',
+  'zu',
+  'zum',
+  'zur',
 ]);
 
 function parseInteger(value, fallback, { min = 1, max = 100 } = {}) {
-  const parsed = Number.parseInt(String(value ?? ""), 10);
+  const parsed = Number.parseInt(String(value ?? ''), 10);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(max, Math.max(min, parsed));
 }
@@ -102,7 +102,7 @@ function parseDecimal(
   fallback,
   { min = 0, max = 1, precision = 2 } = {},
 ) {
-  const parsed = Number.parseFloat(String(value ?? ""));
+  const parsed = Number.parseFloat(String(value ?? ''));
   if (!Number.isFinite(parsed)) return fallback;
   const clamped = Math.min(max, Math.max(min, parsed));
   const factor = 10 ** precision;
@@ -110,8 +110,8 @@ function parseDecimal(
 }
 
 function normalizeWhitespace(value) {
-  return String(value || "")
-    .replace(/\s+/g, " ")
+  return String(value || '')
+    .replace(/\s+/g, ' ')
     .trim();
 }
 
@@ -122,12 +122,12 @@ function trimToLength(value, maxLength) {
 }
 
 function normalizeSearchText(value) {
-  return String(value || "")
+  return String(value || '')
     .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/ß/g, "ss")
-    .replace(/[^a-z0-9]+/g, " ")
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9]+/g, ' ')
     .trim();
 }
 
@@ -143,7 +143,7 @@ function extractSearchTerms(value) {
 
 function scoreTermCoverage(terms, ...texts) {
   if (!Array.isArray(terms) || terms.length === 0) return 0;
-  const haystack = normalizeSearchText(texts.filter(Boolean).join(" "));
+  const haystack = normalizeSearchText(texts.filter(Boolean).join(' '));
   if (!haystack) return 0;
 
   let hits = 0;
@@ -183,11 +183,11 @@ function resolveQueryIntent(query) {
 
 function getSourceIntentBoost(intent, sourceType) {
   let boost = 0;
-  if (intent.prefersBlog && sourceType === "blog") boost += 0.08;
-  if (intent.prefersProject && sourceType === "project") boost += 0.08;
-  if (intent.prefersVideo && sourceType === "video") boost += 0.08;
-  if (intent.prefersAbout && sourceType === "about") boost += 0.08;
-  if (intent.seeksOpinion && sourceType === "blog") boost += 0.05;
+  if (intent.prefersBlog && sourceType === 'blog') boost += 0.08;
+  if (intent.prefersProject && sourceType === 'project') boost += 0.08;
+  if (intent.prefersVideo && sourceType === 'video') boost += 0.08;
+  if (intent.prefersAbout && sourceType === 'about') boost += 0.08;
+  if (intent.seeksOpinion && sourceType === 'blog') boost += 0.05;
   return boost;
 }
 
@@ -208,7 +208,7 @@ function rerankMatch(match, intent) {
     `${match.title} ${match.section}`,
   );
   const normalizedContent = normalizeSearchText(
-    [match.content, match.snippet, match.category, match.tagsText].join(" "),
+    [match.content, match.snippet, match.category, match.tagsText].join(' '),
   );
   const phrase = intent.normalizedQuery;
   const exactTitleHit =
@@ -261,7 +261,7 @@ function buildIntentMetadataFilter(intent) {
     !intent.prefersAbout &&
     !intent.seeksOpinion
   ) {
-    return { sourceType: "project" };
+    return { sourceType: 'project' };
   }
 
   if (
@@ -270,15 +270,15 @@ function buildIntentMetadataFilter(intent) {
     !intent.prefersVideo &&
     !intent.prefersAbout
   ) {
-    return { sourceType: "blog" };
+    return { sourceType: 'blog' };
   }
 
   if (intent.prefersVideo && !intent.prefersProject && !intent.prefersAbout) {
-    return { sourceType: "video" };
+    return { sourceType: 'video' };
   }
 
   if (intent.prefersAbout && !intent.prefersProject && !intent.prefersVideo) {
-    return { sourceType: "about" };
+    return { sourceType: 'about' };
   }
 
   if (
@@ -287,7 +287,7 @@ function buildIntentMetadataFilter(intent) {
     !intent.prefersVideo &&
     !intent.prefersAbout
   ) {
-    return { sourceType: "blog" };
+    return { sourceType: 'blog' };
   }
 
   return null;
@@ -306,7 +306,7 @@ function buildSearchRecordText(record) {
       record.url,
     ]
       .filter(Boolean)
-      .join(" "),
+      .join(' '),
   );
 }
 
@@ -327,7 +327,7 @@ function scoreLexicalRecord(record, intent) {
     record.url,
   );
   const normalizedTitle = normalizeSearchText(
-    `${record.title} ${record.section || ""}`,
+    `${record.title} ${record.section || ''}`,
   );
   const normalizedText = normalizeSearchText(record.searchText);
   const exactTitleHit =
@@ -378,7 +378,7 @@ function selectLexicalMatches(
       if (right.keywordScore !== left.keywordScore) {
         return right.keywordScore - left.keywordScore;
       }
-      return left.title.localeCompare(right.title, "de");
+      return left.title.localeCompare(right.title, 'de');
     })
     .slice(0, config.hybridCandidateK);
 }
@@ -444,7 +444,7 @@ async function queryContentRagIndex(index, vector, options, filter) {
   } catch (error) {
     if (!error?.remote) {
       console.warn(
-        "Content RAG metadata filter fallback:",
+        'Content RAG metadata filter fallback:',
         error?.message || error,
       );
     }
@@ -460,35 +460,35 @@ async function queryContentRagIndex(index, vector, options, filter) {
 async function hashText(value) {
   const input = normalizeWhitespace(value);
   const bytes = new TextEncoder().encode(input);
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
   return Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, "0"),
-  ).join("");
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
 }
 
 function removeFrontmatter(text) {
-  return String(text || "").replace(/^---\n[\s\S]*?\n---\n?/m, "");
+  return String(text || '').replace(/^---\n[\s\S]*?\n---\n?/m, '');
 }
 
 function stripMarkdown(text) {
   return removeFrontmatter(text)
     .replace(/```([\s\S]*?)```/g, (_match, code) => `\n${code}\n`)
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/!\[[^\]]*]\([^)]*\)/g, " ")
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
-    .replace(/^>\s*/gm, "")
-    .replace(/^[-*+]\s+/gm, "")
-    .replace(/^\d+\.\s+/gm, "")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/[|]+/g, " ")
-    .replace(/\r/g, "")
-    .replace(/\n{3,}/g, "\n\n")
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/^>\s*/gm, '')
+    .replace(/^[-*+]\s+/gm, '')
+    .replace(/^\d+\.\s+/gm, '')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/[|]+/g, ' ')
+    .replace(/\r/g, '')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
 
 function stripHtml(text) {
-  const withoutBlocks = ["script", "style"].reduce((current, tagName) => {
-    let output = String(current || "");
+  const withoutBlocks = ['script', 'style'].reduce((current, tagName) => {
+    let output = String(current || '');
     let searchOffset = 0;
 
     while (searchOffset < output.length) {
@@ -496,7 +496,7 @@ function stripHtml(text) {
       const start = lower.indexOf(`<${tagName}`, searchOffset);
       if (start === -1) break;
 
-      const openEnd = lower.indexOf(">", start);
+      const openEnd = lower.indexOf('>', start);
       if (openEnd === -1) {
         output = `${output.slice(0, start)} ${output.slice(start)}`;
         break;
@@ -508,7 +508,7 @@ function stripHtml(text) {
         break;
       }
 
-      const closeEnd = lower.indexOf(">", closeStart);
+      const closeEnd = lower.indexOf('>', closeStart);
       if (closeEnd === -1) {
         output = `${output.slice(0, start)} ${output.slice(closeStart)}`;
         break;
@@ -521,35 +521,35 @@ function stripHtml(text) {
     return output;
   }, text);
 
-  return String(withoutBlocks || "")
+  return String(withoutBlocks || '')
     .replace(
       /<\/(p|div|section|article|main|header|footer|ul|ol|li|br)>/gi,
-      "\n",
+      '\n',
     )
-    .replace(/<(h[1-6])\b[^>]*>/gi, "\n## ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, " and ")
+    .replace(/<(h[1-6])\b[^>]*>/gi, '\n## ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, ' and ')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/gi, "'")
-    .replace(/&lt;/gi, " ")
-    .replace(/&gt;/gi, " ")
-    .replace(/\r/g, "")
-    .replace(/\n{3,}/g, "\n\n")
+    .replace(/&lt;/gi, ' ')
+    .replace(/&gt;/gi, ' ')
+    .replace(/\r/g, '')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
 
 function parseFrontmatter(text) {
-  const source = String(text ?? "");
+  const source = String(text ?? '');
   const match = source.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return { content: source, data: {} };
 
   const data = {};
-  for (const rawLine of match[1].split("\n")) {
+  for (const rawLine of match[1].split('\n')) {
     const line = rawLine.trim();
-    if (!line || line.startsWith("#")) continue;
+    if (!line || line.startsWith('#')) continue;
 
-    const separatorIndex = line.indexOf(":");
+    const separatorIndex = line.indexOf(':');
     if (separatorIndex === -1) continue;
 
     const key = line.slice(0, separatorIndex).trim();
@@ -564,7 +564,7 @@ function parseFrontmatter(text) {
 }
 
 function splitSectionParagraphs(text) {
-  return String(text || "")
+  return String(text || '')
     .split(/\n\s*\n+/)
     .map((part) => normalizeWhitespace(stripMarkdown(part)))
     .filter(Boolean);
@@ -587,7 +587,7 @@ function splitLongSegment(text, maxChars) {
   }
 
   const parts = [];
-  let current = "";
+  let current = '';
   for (const sentence of sentences) {
     if (!sentence) continue;
     const candidate = current ? `${current} ${sentence}` : sentence;
@@ -598,7 +598,7 @@ function splitLongSegment(text, maxChars) {
     if (current) parts.push(current);
     if (sentence.length > maxChars) {
       parts.push(...splitLongSegment(sentence, maxChars));
-      current = "";
+      current = '';
     } else {
       current = sentence;
     }
@@ -609,15 +609,15 @@ function splitLongSegment(text, maxChars) {
 }
 
 function splitMarkdownSections(markdown) {
-  const content = removeFrontmatter(markdown).replace(/\r/g, "").trim();
+  const content = removeFrontmatter(markdown).replace(/\r/g, '').trim();
   if (!content) return [];
 
   const sections = [];
-  let currentTitle = "Einleitung";
+  let currentTitle = 'Einleitung';
   let buffer = [];
 
   const pushSection = () => {
-    const value = buffer.join("\n").trim();
+    const value = buffer.join('\n').trim();
     if (!value) return;
     sections.push({
       title: currentTitle,
@@ -626,7 +626,7 @@ function splitMarkdownSections(markdown) {
     buffer = [];
   };
 
-  for (const line of content.split("\n")) {
+  for (const line of content.split('\n')) {
     const headingMatch = line.match(/^#{2,4}\s+(.+)$/);
     if (headingMatch) {
       pushSection();
@@ -641,12 +641,12 @@ function splitMarkdownSections(markdown) {
 }
 
 function slugifyId(value) {
-  return String(value || "")
+  return String(value || '')
     .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
     .slice(0, 48);
 }
 
@@ -660,15 +660,15 @@ function buildVectorId(documentId, chunkIndex) {
 function buildChunkText(document, sectionTitle, chunkText) {
   return [
     `${document.sourceLabel}: ${document.title}`,
-    document.category ? `Kategorie: ${document.category}` : "",
-    document.date ? `Datum: ${document.date}` : "",
-    document.tagsText ? `Tags: ${document.tagsText}` : "",
-    sectionTitle ? `Abschnitt: ${sectionTitle}` : "",
-    document.summary ? `Kurzfassung: ${document.summary}` : "",
+    document.category ? `Kategorie: ${document.category}` : '',
+    document.date ? `Datum: ${document.date}` : '',
+    document.tagsText ? `Tags: ${document.tagsText}` : '',
+    sectionTitle ? `Abschnitt: ${sectionTitle}` : '',
+    document.summary ? `Kurzfassung: ${document.summary}` : '',
     chunkText,
   ]
     .filter(Boolean)
-    .join("\n");
+    .join('\n');
 }
 
 function chunkDocument(document, rawText, options = {}) {
@@ -679,7 +679,7 @@ function chunkDocument(document, rawText, options = {}) {
   let chunkIndex = 0;
 
   for (const section of sections) {
-    const sectionTitle = normalizeWhitespace(section.title || "Inhalt");
+    const sectionTitle = normalizeWhitespace(section.title || 'Inhalt');
     const paragraphSegments = splitSectionParagraphs(section.text).flatMap(
       (paragraph) => splitLongSegment(paragraph, maxChars),
     );
@@ -687,7 +687,7 @@ function chunkDocument(document, rawText, options = {}) {
     let currentParts = [];
     let currentLength = 0;
     const flushChunk = () => {
-      const chunkText = normalizeWhitespace(currentParts.join(" "));
+      const chunkText = normalizeWhitespace(currentParts.join(' '));
       if (!chunkText) return;
       chunks.push({
         id: buildVectorId(document.documentId, chunkIndex),
@@ -731,20 +731,20 @@ function chunkDocument(document, rawText, options = {}) {
 function buildProjectMarkdown(project) {
   const caseStudy = project.caseStudy || {};
   const sections = [
-    "## Projektüberblick",
-    project.description || "",
+    '## Projektüberblick',
+    project.description || '',
     Array.isArray(project.tags) && project.tags.length > 0
-      ? `Tags: ${project.tags.join(", ")}`
-      : "",
-    caseStudy.problem ? `## Problem\n${caseStudy.problem}` : "",
-    caseStudy.solution ? `## Lösung\n${caseStudy.solution}` : "",
+      ? `Tags: ${project.tags.join(', ')}`
+      : '',
+    caseStudy.problem ? `## Problem\n${caseStudy.problem}` : '',
+    caseStudy.solution ? `## Lösung\n${caseStudy.solution}` : '',
     Array.isArray(caseStudy.techStack) && caseStudy.techStack.length > 0
-      ? `## Tech-Stack\n${caseStudy.techStack.join(", ")}`
-      : "",
-    caseStudy.results ? `## Ergebnis\n${caseStudy.results}` : "",
+      ? `## Tech-Stack\n${caseStudy.techStack.join(', ')}`
+      : '',
+    caseStudy.results ? `## Ergebnis\n${caseStudy.results}` : '',
   ];
 
-  return sections.filter(Boolean).join("\n\n");
+  return sections.filter(Boolean).join('\n\n');
 }
 
 async function loadJsonAsset(env, requestUrl, path) {
@@ -755,21 +755,21 @@ async function loadJsonAsset(env, requestUrl, path) {
 }
 
 async function loadTextAsset(env, requestUrl, path) {
-  if (!env?.ASSETS) return "";
+  if (!env?.ASSETS) return '';
   const response = await env.ASSETS.fetch(new URL(path, requestUrl));
-  if (!response.ok) return "";
+  if (!response.ok) return '';
   return await response.text();
 }
 
 function buildVideoMarkdown(video) {
   return [
-    "## Video",
-    video.description || "",
-    video.channelTitle ? `Kanal: ${video.channelTitle}` : "",
-    video.publishedAt ? `Veröffentlicht: ${video.publishedAt}` : "",
+    '## Video',
+    video.description || '',
+    video.channelTitle ? `Kanal: ${video.channelTitle}` : '',
+    video.publishedAt ? `Veröffentlicht: ${video.publishedAt}` : '',
   ]
     .filter(Boolean)
-    .join("\n\n");
+    .join('\n\n');
 }
 
 async function loadAboutDocuments(context) {
@@ -793,15 +793,15 @@ async function loadAboutDocuments(context) {
 
   return [
     {
-      documentId: "about-profile",
-      sourceType: "about",
-      sourceLabel: "Profil",
-      title: normalizeWhitespace(titleMatch?.[1] || "Über Abdulkerim Sesli"),
-      url: "/about/",
+      documentId: 'about-profile',
+      sourceType: 'about',
+      sourceLabel: 'Profil',
+      title: normalizeWhitespace(titleMatch?.[1] || 'Über Abdulkerim Sesli'),
+      url: '/about/',
       summary: normalizeWhitespace(descriptionMatch?.[1]),
-      category: "profil",
+      category: 'profil',
       date: normalizeWhitespace(dateMatch?.[1]),
-      tagsText: "about, profil, tech stack, services, career, berlin",
+      tagsText: 'about, profil, tech stack, services, career, berlin',
       rawText,
     },
   ];
@@ -837,8 +837,8 @@ async function loadBlogDocuments(context) {
 
       return {
         documentId: `blog-${slugifyId(entry.id)}`,
-        sourceType: "blog",
-        sourceLabel: "Blogpost",
+        sourceType: 'blog',
+        sourceLabel: 'Blogpost',
         title,
         url: `/blog/${encodeURIComponent(entry.id)}/`,
         summary: excerpt,
@@ -869,16 +869,16 @@ async function loadProjectDocuments(context) {
 
       return {
         documentId: `project-${slug}`,
-        sourceType: "project",
-        sourceLabel: "Projekt",
+        sourceType: 'project',
+        sourceLabel: 'Projekt',
         title: normalizeWhitespace(project.title || project.name || slug),
         url: `/projekte/${encodeURIComponent(project.name || slug)}/`,
         summary: normalizeWhitespace(project.description),
         category: normalizeWhitespace(project.category),
-        date: "",
+        date: '',
         tagsText: Array.isArray(project.tags)
-          ? project.tags.map((tag) => normalizeWhitespace(tag)).join(", ")
-          : "",
+          ? project.tags.map((tag) => normalizeWhitespace(tag)).join(', ')
+          : '',
         rawText: buildProjectMarkdown(project),
       };
     })
@@ -896,17 +896,17 @@ async function loadVideoDocuments(context) {
 
       return {
         documentId: `video-${slugifyId(videoId)}`,
-        sourceType: "video",
-        sourceLabel: "Video",
+        sourceType: 'video',
+        sourceLabel: 'Video',
         title: normalizeWhitespace(video.title || `Video ${videoId}`),
         url: normalizeWhitespace(
           video.path || `/videos/${encodeURIComponent(videoId)}/`,
         ),
         summary: trimToLength(video.description, 220),
-        category: "youtube",
+        category: 'youtube',
         date: normalizeWhitespace(video.publishedAt),
         tagsText: normalizeWhitespace(
-          ["video", "youtube", video.channelTitle].filter(Boolean).join(", "),
+          ['video', 'youtube', video.channelTitle].filter(Boolean).join(', '),
         ),
         rawText: buildVideoMarkdown(video),
       };
@@ -1005,7 +1005,7 @@ async function buildDocumentHashes(documents) {
 export async function readContentRagManifest(env) {
   if (!env?.SITEMAP_CACHE_KV) return null;
   try {
-    return await env.SITEMAP_CACHE_KV.get(CONTENT_RAG_MANIFEST_KEY, "json");
+    return await env.SITEMAP_CACHE_KV.get(CONTENT_RAG_MANIFEST_KEY, 'json');
   } catch {
     return null;
   }
@@ -1023,7 +1023,7 @@ async function writeContentRagManifest(env, manifest) {
 async function readContentRagSearchIndex(env) {
   if (!env?.SITEMAP_CACHE_KV) return null;
   try {
-    return await env.SITEMAP_CACHE_KV.get(CONTENT_RAG_SEARCH_INDEX_KEY, "json");
+    return await env.SITEMAP_CACHE_KV.get(CONTENT_RAG_SEARCH_INDEX_KEY, 'json');
   } catch {
     return null;
   }
@@ -1072,9 +1072,9 @@ function buildSearchRecords(chunks) {
       section: chunk.section,
       snippet: chunk.snippet,
       content: trimToLength(chunk.content, DEFAULT_CHUNK_MAX_CHARS),
-      category: chunk.category || "",
-      tagsText: chunk.tagsText || "",
-      date: chunk.date || "",
+      category: chunk.category || '',
+      tagsText: chunk.tagsText || '',
+      date: chunk.date || '',
     };
 
     return {
@@ -1094,14 +1094,14 @@ function buildManifestDocuments(
   const entries = {};
   const previousDocuments =
     previousManifest?.documents &&
-    typeof previousManifest.documents === "object"
+    typeof previousManifest.documents === 'object'
       ? previousManifest.documents
       : {};
 
   for (const document of documents) {
     const documentChunks = chunksByDocument.get(document.documentId) || [];
     const previousEntry = previousDocuments[document.documentId];
-    const currentHash = documentHashes.get(document.documentId) || "";
+    const currentHash = documentHashes.get(document.documentId) || '';
     entries[document.documentId] = {
       hash: currentHash,
       sourceType: document.sourceType,
@@ -1122,14 +1122,14 @@ function buildManifestDocuments(
 function getChangedDocumentIds(documents, documentHashes, previousManifest) {
   const previousDocuments =
     previousManifest?.documents &&
-    typeof previousManifest.documents === "object"
+    typeof previousManifest.documents === 'object'
       ? previousManifest.documents
       : {};
 
   return documents
     .filter((document) => {
       const previousEntry = previousDocuments[document.documentId];
-      const currentHash = documentHashes.get(document.documentId) || "";
+      const currentHash = documentHashes.get(document.documentId) || '';
       return previousEntry?.hash !== currentHash;
     })
     .map((document) => document.documentId);
@@ -1145,7 +1145,7 @@ async function embedCorpusChunks(env, chunks, embeddingModel) {
     const embeddings = Array.isArray(response?.data) ? response.data : [];
 
     if (embeddings.length !== batch.length) {
-      throw new Error("Embedding result count mismatch");
+      throw new Error('Embedding result count mismatch');
     }
 
     for (const [index, item] of batch.entries()) {
@@ -1165,9 +1165,9 @@ async function embedCorpusChunks(env, chunks, embeddingModel) {
           section: item.section,
           snippet: item.snippet,
           content: item.content,
-          category: item.category || "",
-          tags: item.tagsText || "",
-          date: item.date || "",
+          category: item.category || '',
+          tags: item.tagsText || '',
+          date: item.date || '',
         },
       });
     }
@@ -1188,15 +1188,15 @@ async function deleteStaleVectors(index, ids) {
 export async function syncSiteContentRag(context, options = {}) {
   const { env } = context;
   if (!env?.AI) {
-    throw new Error("AI binding is missing");
+    throw new Error('AI binding is missing');
   }
   if (!env?.ROBOT_CONTENT_RAG) {
-    throw new Error("ROBOT_CONTENT_RAG binding is missing");
+    throw new Error('ROBOT_CONTENT_RAG binding is missing');
   }
 
   const corpus = await buildSiteContentCorpus(context);
   if (!corpus.chunks.length) {
-    throw new Error("No website content found for RAG sync");
+    throw new Error('No website content found for RAG sync');
   }
 
   const previousManifest = await readContentRagManifest(env);
@@ -1212,7 +1212,7 @@ export async function syncSiteContentRag(context, options = {}) {
   );
 
   const embeddingModel =
-    env.ROBOT_EMBEDDING_MODEL || "@cf/baai/bge-base-en-v1.5";
+    env.ROBOT_EMBEDDING_MODEL || '@cf/baai/bge-base-en-v1.5';
   const vectors =
     changedChunks.length > 0
       ? await embedCorpusChunks(env, changedChunks, embeddingModel)
@@ -1236,7 +1236,7 @@ export async function syncSiteContentRag(context, options = {}) {
 
   const previousDocumentIds =
     previousManifest?.documents &&
-    typeof previousManifest.documents === "object"
+    typeof previousManifest.documents === 'object'
       ? Object.keys(previousManifest.documents)
       : [];
   const currentDocumentIdSet = new Set(
@@ -1301,7 +1301,7 @@ export async function getSiteContentRagContext(query, env) {
 
   try {
     const embeddingModel =
-      env.ROBOT_EMBEDDING_MODEL || "@cf/baai/bge-base-en-v1.5";
+      env.ROBOT_EMBEDDING_MODEL || '@cf/baai/bge-base-en-v1.5';
     const response = await env.AI.run(embeddingModel, {
       text: [trimmedQuery],
     });
@@ -1323,7 +1323,7 @@ export async function getSiteContentRagContext(query, env) {
       vector,
       {
         topK: rawTopK,
-        returnMetadata: "all",
+        returnMetadata: 'all',
       },
       metadataFilter,
     );
@@ -1332,7 +1332,7 @@ export async function getSiteContentRagContext(query, env) {
         ? `metadata-filter:${appliedFilter.sourceType}`
         : usedFallback && metadataFilter?.sourceType
           ? `fallback-unfiltered:${metadataFilter.sourceType}`
-          : "unfiltered";
+          : 'unfiltered';
     const searchIndex = await readContentRagSearchIndex(env);
 
     const vectorMatches = [];
@@ -1345,7 +1345,7 @@ export async function getSiteContentRagContext(query, env) {
       }
 
       const metadata =
-        match?.metadata && typeof match.metadata === "object"
+        match?.metadata && typeof match.metadata === 'object'
           ? match.metadata
           : {};
       const content = trimToLength(metadata.content, DEFAULT_CHUNK_MAX_CHARS);
@@ -1357,7 +1357,7 @@ export async function getSiteContentRagContext(query, env) {
         id: normalizeWhitespace(match.id),
         documentId: normalizeWhitespace(metadata.documentId || match.id),
         score: Number(match.score.toFixed(3)),
-        sourceType: normalizeWhitespace(metadata.sourceType || "content"),
+        sourceType: normalizeWhitespace(metadata.sourceType || 'content'),
         title,
         url,
         section: normalizeWhitespace(metadata.section),
@@ -1412,32 +1412,32 @@ export async function getSiteContentRagContext(query, env) {
       usedLexicalMatch: matches.some((item) => Number(item.keywordScore) > 0),
     };
     const prompt = [
-      "Nutze die folgenden Primärquellen aus Abdulkerims eigenem Website-Content als bevorzugte Grundlage für Antworten über seine Sichtweisen, Projekte und technischen Entscheidungen.",
+      'Nutze die folgenden Primärquellen aus Abdulkerims eigenem Website-Content als bevorzugte Grundlage für Antworten über seine Sichtweisen, Projekte und technischen Entscheidungen.',
       sources.length > 0
         ? [
             'Wenn du dich inhaltlich auf diesen Kontext stützt, nenne am Ende unter "Quellen:" 1-2 passende Markdown-Links aus dieser Liste und erfinde keine zusätzlichen URLs.',
             ...sources.map((item) => `- [${item.title}](${item.url})`),
-          ].join("\n")
-        : "",
+          ].join('\n')
+        : '',
       ...matches.map((item, index) =>
         [
           `[Quelle ${index + 1}]`,
           `Typ: ${item.sourceType}`,
           `Titel: ${item.title}`,
-          item.date ? `Datum: ${item.date}` : "",
-          item.section ? `Abschnitt: ${item.section}` : "",
+          item.date ? `Datum: ${item.date}` : '',
+          item.section ? `Abschnitt: ${item.section}` : '',
           `Retrieval: ${retrievalMode}`,
-          item.keywordScore ? `Lexical: ${item.keywordScore}` : "",
+          item.keywordScore ? `Lexical: ${item.keywordScore}` : '',
           `Rerank: ${item.rerankScore}`,
           `URL: ${item.url}`,
           `Inhalt: ${item.content}`,
         ]
           .filter(Boolean)
-          .join("\n"),
+          .join('\n'),
       ),
     ]
       .filter(Boolean)
-      .join("\n\n");
+      .join('\n\n');
 
     return {
       prompt,
@@ -1456,7 +1456,7 @@ export async function getSiteContentRagContext(query, env) {
     };
   } catch (error) {
     if (!error?.remote) {
-      console.warn("getSiteContentRagContext error:", error?.message || error);
+      console.warn('getSiteContentRagContext error:', error?.message || error);
     }
     return null;
   }

--- a/functions/api/admin/content-rag.js
+++ b/functions/api/admin/content-rag.js
@@ -2,38 +2,38 @@ import {
   getSiteContentRagContext,
   readContentRagManifest,
   syncSiteContentRag,
-} from "../_content-rag.js";
+} from '../_content-rag.js';
 
 function getJsonHeaders() {
   return {
-    "Content-Type": "application/json",
-    "Cache-Control": "no-store",
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
   };
 }
 
 function getRuntimeInfo(env) {
   return {
-    branch: String(env?.CF_PAGES_BRANCH || "").trim(),
-    commitSha: String(env?.CF_PAGES_COMMIT_SHA || "").trim(),
-    pagesUrl: String(env?.CF_PAGES_URL || "").trim(),
+    branch: String(env?.CF_PAGES_BRANCH || '').trim(),
+    commitSha: String(env?.CF_PAGES_COMMIT_SHA || '').trim(),
+    pagesUrl: String(env?.CF_PAGES_URL || '').trim(),
   };
 }
 
 function parseBooleanFlag(value) {
-  const normalized = String(value || "")
+  const normalized = String(value || '')
     .trim()
     .toLowerCase();
-  return ["1", "true", "yes", "on"].includes(normalized);
+  return ['1', 'true', 'yes', 'on'].includes(normalized);
 }
 
 function authorize(request, env) {
-  const expectedToken = String(env?.ADMIN_TOKEN || "").trim();
+  const expectedToken = String(env?.ADMIN_TOKEN || '').trim();
   if (!expectedToken) {
     return {
       ok: false,
       response: new Response(
         JSON.stringify({
-          error: "Admin configuration error: ADMIN_TOKEN is missing",
+          error: 'Admin configuration error: ADMIN_TOKEN is missing',
         }),
         {
           status: 500,
@@ -43,11 +43,11 @@ function authorize(request, env) {
     };
   }
 
-  const authHeader = request.headers.get("Authorization");
+  const authHeader = request.headers.get('Authorization');
   if (authHeader !== `Bearer ${expectedToken}`) {
     return {
       ok: false,
-      response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+      response: new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401,
         headers: getJsonHeaders(),
       }),
@@ -62,7 +62,7 @@ export async function onRequestGet(context) {
   if (!auth.ok) return auth.response;
   const url = new URL(context.request.url);
   const query = String(
-    url.searchParams.get("query") || url.searchParams.get("q") || "",
+    url.searchParams.get('query') || url.searchParams.get('q') || '',
   ).trim();
 
   if (query) {
@@ -85,7 +85,7 @@ export async function onRequestGet(context) {
         JSON.stringify({
           ok: false,
           query,
-          error: error?.message || "content_rag_query_failed",
+          error: error?.message || 'content_rag_query_failed',
         }),
         {
           status: 500,
@@ -101,7 +101,7 @@ export async function onRequestGet(context) {
       indexInfo = await context.env.ROBOT_CONTENT_RAG.describe();
     } catch (error) {
       indexInfo = {
-        error: error?.message || "describe_failed",
+        error: error?.message || 'describe_failed',
       };
     }
   }
@@ -130,9 +130,9 @@ export async function onRequestPost(context) {
   try {
     const url = new URL(context.request.url);
     const forceReindex =
-      parseBooleanFlag(url.searchParams.get("full")) ||
-      parseBooleanFlag(url.searchParams.get("force")) ||
-      parseBooleanFlag(url.searchParams.get("reindex"));
+      parseBooleanFlag(url.searchParams.get('full')) ||
+      parseBooleanFlag(url.searchParams.get('force')) ||
+      parseBooleanFlag(url.searchParams.get('reindex'));
     const result = await syncSiteContentRag(context, {
       forceReindex,
     });
@@ -150,7 +150,7 @@ export async function onRequestPost(context) {
     return new Response(
       JSON.stringify({
         ok: false,
-        error: error?.message || "content_rag_sync_failed",
+        error: error?.message || 'content_rag_sync_failed',
       }),
       {
         status: 500,

--- a/functions/api/ai-agent.js
+++ b/functions/api/ai-agent.js
@@ -61,6 +61,14 @@ function parseIntegrationSet(
   return new Set(parseCsvList(raw).map((item) => item.toLowerCase()));
 }
 
+function withTimeout(promise, ms, fallback = null) {
+  let timeoutId;
+  const timer = new Promise((resolve) => {
+    timeoutId = setTimeout(() => resolve(fallback), ms);
+  });
+  return Promise.race([promise, timer]).finally(() => clearTimeout(timeoutId));
+}
+
 function getAgentConfig(env) {
   return {
     chatModel: env.ROBOT_CHAT_MODEL || DEFAULT_CHAT_MODEL,
@@ -1323,8 +1331,8 @@ async function persistPromptMemories(env, userId, prompt, config) {
   const facts = extractPromptMemoryFacts(prompt);
   if (!facts.length) return [];
 
-  const stored = [];
-  for (const fact of facts) {
+  const now = Date.now();
+  const memoryPromises = facts.map(async (fact) => {
     try {
       const result = await storeMemory(
         env,
@@ -1333,25 +1341,30 @@ async function persistPromptMemories(env, userId, prompt, config) {
         fact.value,
         config,
       );
-      if (!result?.success) continue;
+      if (!result?.success) return null;
+
       const normalized = normalizeMemoryEntry(
         {
           key: fact.key,
           value: fact.value,
-          timestamp: Date.now(),
+          timestamp: now,
         },
         config,
       );
-      stored.push({
+      return {
         ...normalized,
         score: 1,
-      });
+      };
     } catch {
-      // Skip single-memory errors; keep persisting remaining facts.
+      return null;
     }
-  }
+  });
 
-  return stored;
+  const results = await Promise.allSettled(memoryPromises);
+
+  return results
+    .filter((r) => r.status === 'fulfilled' && r.value !== null)
+    .map((r) => r.value);
 }
 
 async function resolveMemoryContext(env, userId, _prompt, config) {
@@ -1701,15 +1714,24 @@ export async function onRequestPost(context) {
     }
 
     // ── Parallel: memory + RAG + deterministic memory persistence ──
+    const timeoutMs = 3500;
     const [memResult, ragResult, storedPromptMemoriesResult] =
       await Promise.allSettled([
-        resolveMemoryContext(env, userId, prompt, config),
-        getRAGContext(prompt, env),
-        persistPromptMemories(env, userId, prompt, config),
+        withTimeout(
+          resolveMemoryContext(env, userId, prompt, config),
+          timeoutMs,
+          [],
+        ),
+        withTimeout(getRAGContext(prompt, env), timeoutMs, null),
+        withTimeout(
+          persistPromptMemories(env, userId, prompt, config),
+          timeoutMs,
+          [],
+        ),
       ]);
 
     const recalledMemories =
-      memResult.status === 'fulfilled' ? memResult.value : [];
+      memResult.status === 'fulfilled' ? memResult.value || [] : [];
     const storedPromptMemories =
       storedPromptMemoriesResult.status === 'fulfilled'
         ? storedPromptMemoriesResult.value

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
-import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
-import net from "node:net";
-import path from "node:path";
-import process from "node:process";
-import { fileURLToPath } from "node:url";
-import { chromium } from "playwright";
+import { spawn } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import net from 'node:net';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = path.resolve(__dirname, "..");
-const OUTPUT_DIR = path.join(ROOT_DIR, "output/playwright");
-const THEME_STORAGE_KEY = "iweb-theme-preference";
+const ROOT_DIR = path.resolve(__dirname, '..');
+const OUTPUT_DIR = path.join(ROOT_DIR, 'output/playwright');
+const THEME_STORAGE_KEY = 'iweb-theme-preference';
 const DEFAULT_PORT = 4173;
 const DEFAULT_TIMEOUT_MS = 60000;
 const BF_CACHE_TOP_THRESHOLD_PX = 80;
 
 function parseArgs(argv = process.argv.slice(2)) {
   const options = {
-    url: "",
+    url: '',
     port: null,
     headed: false,
     timeoutMs: DEFAULT_TIMEOUT_MS,
@@ -25,36 +25,36 @@ function parseArgs(argv = process.argv.slice(2)) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === "--headed") {
+    if (arg === '--headed') {
       options.headed = true;
       continue;
     }
-    if (arg === "--url") {
-      options.url = String(argv[index + 1] || "").trim();
+    if (arg === '--url') {
+      options.url = String(argv[index + 1] || '').trim();
       index += 1;
       continue;
     }
-    if (arg.startsWith("--url=")) {
-      options.url = String(arg.split("=").slice(1).join("=") || "").trim();
+    if (arg.startsWith('--url=')) {
+      options.url = String(arg.split('=').slice(1).join('=') || '').trim();
       continue;
     }
-    if (arg === "--port") {
+    if (arg === '--port') {
       options.port = Number(argv[index + 1]);
       index += 1;
       continue;
     }
-    if (arg.startsWith("--port=")) {
-      options.port = Number(arg.split("=").slice(1).join("="));
+    if (arg.startsWith('--port=')) {
+      options.port = Number(arg.split('=').slice(1).join('='));
       continue;
     }
-    if (arg === "--timeout") {
+    if (arg === '--timeout') {
       options.timeoutMs = Number(argv[index + 1]) || DEFAULT_TIMEOUT_MS;
       index += 1;
       continue;
     }
-    if (arg.startsWith("--timeout=")) {
+    if (arg.startsWith('--timeout=')) {
       options.timeoutMs =
-        Number(arg.split("=").slice(1).join("=")) || DEFAULT_TIMEOUT_MS;
+        Number(arg.split('=').slice(1).join('=')) || DEFAULT_TIMEOUT_MS;
     }
   }
 
@@ -82,8 +82,8 @@ async function findFreePort(startPort = DEFAULT_PORT) {
     const available = await new Promise((resolve) => {
       const server = net.createServer();
       server.unref();
-      server.on("error", () => resolve(false));
-      server.listen(port, "127.0.0.1", () => {
+      server.on('error', () => resolve(false));
+      server.listen(port, '127.0.0.1', () => {
         server.close(() => resolve(true));
       });
     });
@@ -95,13 +95,13 @@ async function findFreePort(startPort = DEFAULT_PORT) {
     port += 1;
   }
 
-  throw new Error("No free port available for browser smoke test");
+  throw new Error('No free port available for browser smoke test');
 }
 
 function trackChildLogs(child) {
   const lines = [];
   const collect = (chunk, stream) => {
-    const text = String(chunk || "");
+    const text = String(chunk || '');
     if (!text) return;
     for (const line of text.split(/\r?\n/)) {
       if (!line) continue;
@@ -112,10 +112,10 @@ function trackChildLogs(child) {
     }
   };
 
-  child.stdout?.setEncoding("utf8");
-  child.stderr?.setEncoding("utf8");
-  child.stdout?.on("data", (chunk) => collect(chunk, "stdout"));
-  child.stderr?.on("data", (chunk) => collect(chunk, "stderr"));
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk) => collect(chunk, 'stdout'));
+  child.stderr?.on('data', (chunk) => collect(chunk, 'stderr'));
 
   return lines;
 }
@@ -125,11 +125,11 @@ async function stopChildProcess(child) {
 
   await new Promise((resolve) => {
     const finish = () => resolve();
-    child.once("exit", finish);
-    child.kill("SIGTERM");
+    child.once('exit', finish);
+    child.kill('SIGTERM');
     setTimeout(() => {
       if (!child.killed) {
-        child.kill("SIGKILL");
+        child.kill('SIGKILL');
       }
     }, 1500).unref();
   });
@@ -155,20 +155,20 @@ async function waitForServer(url, timeoutMs) {
 async function startDevServer(port, timeoutMs) {
   const child = spawn(
     process.execPath,
-    ["scripts/dev-workflow.mjs", "--port", String(port)],
+    ['scripts/dev-workflow.mjs', '--port', String(port)],
     {
       cwd: ROOT_DIR,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ['ignore', 'pipe', 'pipe'],
       env: process.env,
     },
   );
   const logs = trackChildLogs(child);
 
   const earlyExit = new Promise((_, reject) => {
-    child.once("exit", (code, signal) => {
+    child.once('exit', (code, signal) => {
       reject(
         new Error(
-          `Dev server exited before readiness (code=${code ?? "null"}, signal=${signal ?? "null"}).\nLogs:\n${logs.join("\n")}`,
+          `Dev server exited before readiness (code=${code ?? 'null'}, signal=${signal ?? 'null'}).\nLogs:\n${logs.join('\n')}`,
         ),
       );
     });
@@ -183,9 +183,9 @@ async function startDevServer(port, timeoutMs) {
 async function getRuntimeState(page) {
   return page.evaluate(async () => {
     const [{ loadSignals }, { uiStore }, themeModule] = await Promise.all([
-      import("/content/core/load-manager.js"),
-      import("/content/core/ui-store.js"),
-      import("/content/core/theme-state.js"),
+      import('/content/core/load-manager.js'),
+      import('/content/core/ui-store.js'),
+      import('/content/core/theme-state.js'),
     ]);
 
     return {
@@ -194,7 +194,7 @@ async function getRuntimeState(page) {
         resolved: themeModule.resolvedTheme.value,
         system: themeModule.systemTheme.value,
         storedPreference:
-          globalThis.localStorage?.getItem?.("iweb-theme-preference") || null,
+          globalThis.localStorage?.getItem?.('iweb-theme-preference') || null,
       },
       loading: {
         blocked: loadSignals.blocked.value,
@@ -207,15 +207,15 @@ async function getRuntimeState(page) {
       ui: uiStore.getState(),
       scrollY: globalThis.scrollY,
       smoke: globalThis.__smoke || null,
-      footerExpanded: document.body.classList.contains("footer-expanded"),
+      footerExpanded: document.body.classList.contains('footer-expanded'),
       robotWindowOpen:
         document
-          .querySelector("#robot-chat-window")
-          ?.classList.contains("open") || false,
+          .querySelector('#robot-chat-window')
+          ?.classList.contains('open') || false,
       robotContainerMenuOpen:
         document
-          .querySelector("#robot-companion-container")
-          ?.classList.contains("robot-companion--menu-open") || false,
+          .querySelector('#robot-companion-container')
+          ?.classList.contains('robot-companion--menu-open') || false,
     };
   });
 }
@@ -240,7 +240,7 @@ async function waitForState(page, label, predicate, timeoutMs = 15000) {
 async function waitForAppReady(page, timeoutMs = 20000) {
   return page.evaluate(
     async ({ timeout }) => {
-      const { whenAppReady } = await import("/content/core/load-manager.js");
+      const { whenAppReady } = await import('/content/core/load-manager.js');
       return whenAppReady({ timeout });
     },
     { timeout: timeoutMs },
@@ -249,9 +249,9 @@ async function waitForAppReady(page, timeoutMs = 20000) {
 
 async function clickMenuControl(page, selector) {
   await page.evaluate((value) => {
-    const host = document.querySelector("site-menu");
+    const host = document.querySelector('site-menu');
     if (!(host instanceof HTMLElement)) {
-      throw new Error("site-menu host not found");
+      throw new Error('site-menu host not found');
     }
 
     const root = host.shadowRoot || host;
@@ -280,68 +280,68 @@ async function clickDomSelector(page, selector) {
 
 async function fillMenuSearch(page, value) {
   await page.evaluate((nextValue) => {
-    const host = document.querySelector("site-menu");
+    const host = document.querySelector('site-menu');
     if (!(host instanceof HTMLElement)) {
-      throw new Error("site-menu host not found");
+      throw new Error('site-menu host not found');
     }
 
     const root = host.shadowRoot || host;
-    const input = root.querySelector(".menu-search__input");
+    const input = root.querySelector('.menu-search__input');
     if (!(input instanceof HTMLInputElement)) {
-      throw new Error("Menu search input not found");
+      throw new Error('Menu search input not found');
     }
 
     input.focus();
     input.value = nextValue;
-    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
   }, value);
 }
 
 async function getMenuSearchSnapshot(page) {
   return page.evaluate(() => {
-    const host = document.querySelector("site-menu");
+    const host = document.querySelector('site-menu');
     if (!(host instanceof HTMLElement)) {
-      return { resultsCount: 0, stateText: "", aiText: "" };
+      return { resultsCount: 0, stateText: '', aiText: '' };
     }
 
     const root = host.shadowRoot || host;
     return {
-      resultsCount: root.querySelectorAll("[data-search-index]").length,
-      stateText: root.querySelector(".menu-search__state")?.textContent || "",
-      aiText: root.querySelector(".menu-search__ai-text")?.textContent || "",
+      resultsCount: root.querySelectorAll('[data-search-index]').length,
+      stateText: root.querySelector('.menu-search__state')?.textContent || '',
+      aiText: root.querySelector('.menu-search__ai-text')?.textContent || '',
     };
   });
 }
 
 function buildSearchPayload(query) {
-  const normalized = String(query || "")
+  const normalized = String(query || '')
     .trim()
     .toLowerCase();
-  const hasBlogMatch = normalized.includes("blog");
+  const hasBlogMatch = normalized.includes('blog');
   return {
     results: hasBlogMatch
       ? [
           {
-            title: "Blog",
-            url: "/blog/",
-            description: "Artikel und Updates",
+            title: 'Blog',
+            url: '/blog/',
+            description: 'Artikel und Updates',
             highlightedDescription:
-              "<mark>Blog</mark> Artikel und Updates aus dem Archiv",
-            category: "blog",
+              '<mark>Blog</mark> Artikel und Updates aus dem Archiv',
+            category: 'blog',
           },
         ]
       : [],
     aiChat: {
       message: hasBlogMatch
-        ? "Direkter Treffer: [Blog](/blog/)."
-        : "Keine direkten Treffer.",
+        ? 'Direkter Treffer: [Blog](/blog/).'
+        : 'Keine direkten Treffer.',
     },
   };
 }
 
 async function installRoutes(context) {
-  await context.route("**/api/search", async (route) => {
-    const rawBody = route.request().postData() || "{}";
+  await context.route('**/api/search', async (route) => {
+    const rawBody = route.request().postData() || '{}';
     const body = (() => {
       try {
         return JSON.parse(rawBody);
@@ -352,17 +352,17 @@ async function installRoutes(context) {
 
     await route.fulfill({
       status: 200,
-      contentType: "application/json; charset=utf-8",
+      contentType: 'application/json; charset=utf-8',
       body: JSON.stringify(buildSearchPayload(body.query)),
     });
   });
 
-  await context.route("**/api/ai-agent", async (route) => {
+  await context.route('**/api/ai-agent', async (route) => {
     await route.fulfill({
       status: 200,
-      contentType: "application/json; charset=utf-8",
+      contentType: 'application/json; charset=utf-8',
       body: JSON.stringify({
-        text: "Kurzantwort mit [Blog](/blog/).",
+        text: 'Kurzantwort mit [Blog](/blog/).',
         toolCalls: [],
         hasMemory: false,
         hasImage: false,
@@ -374,14 +374,14 @@ async function installRoutes(context) {
 async function writeArtifacts(summary, diagnostics) {
   await mkdir(OUTPUT_DIR, { recursive: true });
   await writeFile(
-    path.join(OUTPUT_DIR, "browser-smoke-summary.json"),
+    path.join(OUTPUT_DIR, 'browser-smoke-summary.json'),
     `${JSON.stringify(summary, null, 2)}\n`,
-    "utf8",
+    'utf8',
   );
   await writeFile(
-    path.join(OUTPUT_DIR, "browser-smoke-diagnostics.json"),
+    path.join(OUTPUT_DIR, 'browser-smoke-diagnostics.json'),
     `${JSON.stringify(diagnostics, null, 2)}\n`,
-    "utf8",
+    'utf8',
   );
 }
 
@@ -394,7 +394,7 @@ async function runSmoke() {
     serverLogs: [],
   };
   const summary = {
-    baseUrl: "",
+    baseUrl: '',
     actualBfcacheRestore: false,
     usedSyntheticBfcacheCheck: false,
     checks: [],
@@ -407,22 +407,22 @@ async function runSmoke() {
 
   try {
     if (options.url) {
-      summary.baseUrl = String(options.url).replace(/\/+$/, "");
+      summary.baseUrl = String(options.url).replace(/\/+$/, '');
       logStep(`using existing server ${summary.baseUrl}`);
     } else {
       const port = options.port || (await findFreePort(DEFAULT_PORT));
       logStep(`starting dev server on port ${port}`);
       server = await startDevServer(port, options.timeoutMs);
       diagnostics.serverLogs = server.logs;
-      summary.baseUrl = server.url.replace(/\/+$/, "");
+      summary.baseUrl = server.url.replace(/\/+$/, '');
     }
 
-    logStep("launching Chromium");
+    logStep('launching Chromium');
     browser = await chromium.launch({ headless: !options.headed });
     context = await browser.newContext({
       viewport: { width: 1440, height: 1100 },
-      locale: "de-DE",
-      timezoneId: "Europe/Berlin",
+      locale: 'de-DE',
+      timezoneId: 'Europe/Berlin',
     });
 
     await context.addInitScript(
@@ -436,7 +436,7 @@ async function runSmoke() {
 
         try {
           if (!globalThis.localStorage?.getItem(storageKey)) {
-            globalThis.localStorage?.setItem(storageKey, "light");
+            globalThis.localStorage?.setItem(storageKey, 'light');
           }
         } catch {
           /* ignore */
@@ -449,7 +449,7 @@ async function runSmoke() {
         ) {
           if (
             this === document.documentElement &&
-            name === "data-theme" &&
+            name === 'data-theme' &&
             !globalThis.__smoke.firstThemeSet
           ) {
             globalThis.__smoke.firstThemeSet = String(value);
@@ -458,16 +458,16 @@ async function runSmoke() {
           return originalSetAttribute.call(this, name, value);
         };
 
-        globalThis.addEventListener("pageshow", (event) => {
+        globalThis.addEventListener('pageshow', (event) => {
           globalThis.__smoke.pageshowEvents.push({
             persisted: Boolean(event.persisted),
             href: `${location.pathname}${location.search}`,
           });
         });
-        globalThis.addEventListener("resize", () => {
+        globalThis.addEventListener('resize', () => {
           globalThis.__smoke.resizeEvents += 1;
         });
-        document.addEventListener("visibilitychange", () => {
+        document.addEventListener('visibilitychange', () => {
           globalThis.__smoke.visibilityEvents += 1;
         });
       },
@@ -477,21 +477,21 @@ async function runSmoke() {
     await installRoutes(context);
 
     page = await context.newPage();
-    page.on("console", (message) => {
-      if (message.type() === "error") {
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
         diagnostics.consoleErrors.push(message.text());
       }
     });
-    page.on("pageerror", (error) => {
+    page.on('pageerror', (error) => {
       diagnostics.pageErrors.push(
         String(error?.stack || error?.message || error),
       );
     });
-    page.on("requestfailed", (request) => {
+    page.on('requestfailed', (request) => {
       const resourceType = request.resourceType();
-      if (!["document", "script", "fetch", "xhr"].includes(resourceType))
+      if (!['document', 'script', 'fetch', 'xhr'].includes(resourceType))
         return;
-      const failure = request.failure()?.errorText || "unknown failure";
+      const failure = request.failure()?.errorText || 'unknown failure';
       if (/aborted/i.test(failure)) return;
       diagnostics.requestFailures.push({
         url: request.url(),
@@ -503,102 +503,102 @@ async function runSmoke() {
 
     const runId = Date.now();
     const homeUrl = `${summary.baseUrl}/?test=1&t=${runId}`;
-    logStep("opening home page");
+    logStep('opening home page');
     await page.goto(homeUrl, {
-      waitUntil: "domcontentloaded",
+      waitUntil: 'domcontentloaded',
       timeout: options.timeoutMs,
     });
     await waitForAppReady(page, 20000);
 
     let state = await waitForState(
       page,
-      "app lifecycle ready",
+      'app lifecycle ready',
       (value) => value?.loading?.done === true,
       20000,
     );
     assert(
-      state.smoke.firstThemeSet === "light",
+      state.smoke.firstThemeSet === 'light',
       `Expected bootstrap theme to start as light, received ${state.smoke.firstThemeSet}`,
     );
     assert(
-      state.theme.resolved === "light",
+      state.theme.resolved === 'light',
       `Expected resolved theme to be light after bootstrap, received ${state.theme.resolved}`,
     );
     assert(
       state.loading.blocked === false,
-      "Loader remained blocked after load completion",
+      'Loader remained blocked after load completion',
     );
     summary.checks.push(
-      "theme bootstrap picks persisted preference before app init",
+      'theme bootstrap picks persisted preference before app init',
     );
-    summary.checks.push("loadSignals finish and unblock the app lifecycle");
+    summary.checks.push('loadSignals finish and unblock the app lifecycle');
 
-    logStep("toggling theme and verifying persistence");
-    await clickMenuControl(page, ".site-menu__toggle");
+    logStep('toggling theme and verifying persistence');
+    await clickMenuControl(page, '.site-menu__toggle');
     await waitForState(
       page,
-      "menu open",
+      'menu open',
       (value) => value.ui.menuOpen === true,
       8000,
     );
-    await clickMenuControl(page, ".theme-toggle");
+    await clickMenuControl(page, '.theme-toggle');
     state = await waitForState(
       page,
-      "dark theme active",
+      'dark theme active',
       (value) =>
-        value.theme.resolved === "dark" &&
-        value.theme.storedPreference === "dark",
+        value.theme.resolved === 'dark' &&
+        value.theme.storedPreference === 'dark',
       8000,
     );
     assert(
-      state.theme.storedPreference === "dark",
+      state.theme.storedPreference === 'dark',
       `Expected stored theme preference to be dark, received ${state.theme.storedPreference}`,
     );
     await page.reload({
-      waitUntil: "domcontentloaded",
+      waitUntil: 'domcontentloaded',
       timeout: options.timeoutMs,
     });
     await waitForAppReady(page, 20000);
     state = await waitForState(
       page,
-      "dark theme restored after reload",
+      'dark theme restored after reload',
       (value) =>
-        value.theme.resolved === "dark" &&
+        value.theme.resolved === 'dark' &&
         value.loading.done === true &&
-        value.smoke.firstThemeSet === "dark",
+        value.smoke.firstThemeSet === 'dark',
       20000,
     );
-    summary.checks.push("theme toggle persists across reload and bootstrap");
+    summary.checks.push('theme toggle persists across reload and bootstrap');
 
-    logStep("waiting for robot hydration");
-    await page.waitForSelector(".robot-avatar", {
-      state: "visible",
+    logStep('waiting for robot hydration');
+    await page.waitForSelector('.robot-avatar', {
+      state: 'visible',
       timeout: 15000,
     });
     state = await waitForState(
       page,
-      "robot hydration",
+      'robot hydration',
       (value) => value.ui.robotHydrated === true,
       15000,
     );
     assert(
       state.ui.robotHydrated === true,
-      "Robot never reached hydrated state",
+      'Robot never reached hydrated state',
     );
 
-    logStep("opening robot chat and checking menu interplay");
-    await clickDomSelector(page, ".robot-avatar");
+    logStep('opening robot chat and checking menu interplay');
+    await clickDomSelector(page, '.robot-avatar');
     state = await waitForState(
       page,
-      "robot chat open",
+      'robot chat open',
       (value) =>
         value.ui.robotChatOpen === true && value.robotWindowOpen === true,
       12000,
     );
-    await clickMenuControl(page, ".site-menu__toggle");
+    await clickMenuControl(page, '.site-menu__toggle');
     state = await waitForState(
       page,
-      "menu closes robot chat",
+      'menu closes robot chat',
       (value) =>
         value.ui.menuOpen === true &&
         value.ui.robotChatOpen === false &&
@@ -606,18 +606,18 @@ async function runSmoke() {
       12000,
     );
     summary.checks.push(
-      "opening the menu closes robot chat and syncs robot UI state",
+      'opening the menu closes robot chat and syncs robot UI state',
     );
 
-    logStep("opening search with stubbed results");
-    await clickMenuControl(page, ".search-trigger");
+    logStep('opening search with stubbed results');
+    await clickMenuControl(page, '.search-trigger');
     state = await waitForState(
       page,
-      "search open",
+      'search open',
       (value) => value.ui.searchOpen === true && value.ui.menuOpen === false,
       8000,
     );
-    await fillMenuSearch(page, "blog");
+    await fillMenuSearch(page, 'blog');
     const searchStart = Date.now();
     let searchSnapshot = await getMenuSearchSnapshot(page);
     while (Date.now() - searchStart < 8000 && searchSnapshot.resultsCount < 1) {
@@ -630,67 +630,67 @@ async function runSmoke() {
       `Expected at least one search result, received ${JSON.stringify(searchSnapshot)}`,
     );
     assert(
-      String(searchSnapshot.aiText || "").includes("Blog"),
+      String(searchSnapshot.aiText || '').includes('Blog'),
       `Expected AI search summary to mention Blog, received ${searchSnapshot.aiText}`,
     );
-    await page.keyboard.press("Escape");
+    await page.keyboard.press('Escape');
     state = await waitForState(
       page,
-      "search closed",
+      'search closed',
       (value) => value.ui.searchOpen === false,
       8000,
     );
     summary.checks.push(
-      "menu search resolves via shared store and closes cleanly",
+      'menu search resolves via shared store and closes cleanly',
     );
 
-    logStep("checking footer hydration path");
-    await clickDomSelector(page, "[data-footer-trigger]");
+    logStep('checking footer hydration path');
+    await clickDomSelector(page, '[data-footer-trigger]');
     state = await waitForState(
       page,
-      "footer expanded",
+      'footer expanded',
       (value) => value.footerExpanded === true,
       12000,
     );
     assert(
       state.footerExpanded === true,
-      "Footer did not expand after trigger click",
+      'Footer did not expand after trigger click',
     );
-    summary.checks.push("footer lazy hydration still opens on user intent");
+    summary.checks.push('footer lazy hydration still opens on user intent');
     await page.evaluate(async () => {
-      const module = await import("/content/components/footer/footer.js");
+      const module = await import('/content/components/footer/footer.js');
       module.closeFooter();
     });
     await waitForState(
       page,
-      "footer collapsed",
+      'footer collapsed',
       (value) => value.footerExpanded === false,
       8000,
     );
 
-    logStep("checking bfcache restore handling");
+    logStep('checking bfcache restore handling');
     await page.evaluate(() => {
       globalThis.scrollTo(0, 320);
     });
     const aboutUrl = `${summary.baseUrl}/about/?test=1&t=${runId + 1}`;
     await page.goto(aboutUrl, {
-      waitUntil: "domcontentloaded",
+      waitUntil: 'domcontentloaded',
       timeout: options.timeoutMs,
     });
     await waitForAppReady(page, 20000);
     await waitForState(
       page,
-      "about lifecycle ready",
+      'about lifecycle ready',
       (value) => value.loading.done === true,
       20000,
     );
     await page.goBack({
-      waitUntil: "domcontentloaded",
+      waitUntil: 'domcontentloaded',
       timeout: options.timeoutMs,
     });
     state = await waitForState(
       page,
-      "home restored",
+      'home restored',
       (value) => value.loading.done === true,
       20000,
     );
@@ -709,7 +709,7 @@ async function runSmoke() {
       );
       assert(
         Number(state.smoke?.resizeEvents || 0) > 0,
-        "Expected BFCache restore path to dispatch resize",
+        'Expected BFCache restore path to dispatch resize',
       );
     } else {
       summary.usedSyntheticBfcacheCheck = true;
@@ -717,8 +717,8 @@ async function runSmoke() {
         globalThis.__smoke.resizeEvents = 0;
         globalThis.__smoke.visibilityEvents = 0;
         globalThis.scrollTo(0, 320);
-        const event = new Event("pageshow");
-        Object.defineProperty(event, "persisted", {
+        const event = new Event('pageshow');
+        Object.defineProperty(event, 'persisted', {
           value: true,
           configurable: true,
         });
@@ -736,26 +736,26 @@ async function runSmoke() {
 
       assert(
         synthetic.resizeEvents > 0,
-        "Synthetic BFCache restore did not dispatch resize",
+        'Synthetic BFCache restore did not dispatch resize',
       );
       assert(
         synthetic.visibilityEvents > 0,
-        "Synthetic BFCache restore did not dispatch visibilitychange",
+        'Synthetic BFCache restore did not dispatch visibilitychange',
       );
       assert(
         synthetic.scrollY <= BF_CACHE_TOP_THRESHOLD_PX,
         `Synthetic BFCache restore did not reset scroll, received ${synthetic.scrollY}`,
       );
     }
-    summary.checks.push("bfcache restore path resumes layout/scroll lifecycle");
+    summary.checks.push('bfcache restore path resumes layout/scroll lifecycle');
 
     assert(
       diagnostics.consoleErrors.length === 0,
-      `Console errors detected: ${diagnostics.consoleErrors.join(" | ")}`,
+      `Console errors detected: ${diagnostics.consoleErrors.join(' | ')}`,
     );
     assert(
       diagnostics.pageErrors.length === 0,
-      `Page errors detected: ${diagnostics.pageErrors.join(" | ")}`,
+      `Page errors detected: ${diagnostics.pageErrors.join(' | ')}`,
     );
     assert(
       diagnostics.requestFailures.length === 0,
@@ -763,13 +763,13 @@ async function runSmoke() {
     );
 
     await writeArtifacts(summary, diagnostics);
-    logStep("browser smoke passed");
+    logStep('browser smoke passed');
   } catch (error) {
     await mkdir(OUTPUT_DIR, { recursive: true });
     if (page) {
       try {
         await page.screenshot({
-          path: path.join(OUTPUT_DIR, "browser-smoke-failure.png"),
+          path: path.join(OUTPUT_DIR, 'browser-smoke-failure.png'),
           fullPage: true,
         });
       } catch {
@@ -808,7 +808,7 @@ runSmoke()
     console.error(`[smoke] failed: ${message}`);
     if (/Executable doesn't exist|browserType\.launch/i.test(message)) {
       console.error(
-        "[smoke] hint: run `npx playwright install chromium` once.",
+        '[smoke] hint: run `npx playwright install chromium` once.',
       );
     }
     process.exit(1);

--- a/scripts/evaluate-content-rag.mjs
+++ b/scripts/evaluate-content-rag.mjs
@@ -1,29 +1,29 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const DEFAULT_BASE_URL = "http://127.0.0.1:8788";
+const DEFAULT_BASE_URL = 'http://127.0.0.1:8788';
 const DEFAULT_DELAY_MS = 5000;
 const DEFAULT_FIXTURE_PATH = fileURLToPath(
-  new URL("../tests/fixtures/content-rag-evals.json", import.meta.url),
+  new URL('../tests/fixtures/content-rag-evals.json', import.meta.url),
 );
 const DEFAULT_RETRIES = 4;
-const ENDPOINT_PATH = "/api/admin/content-rag";
+const ENDPOINT_PATH = '/api/admin/content-rag';
 
 function getFlagValue(name) {
   const exactIndex = process.argv.findIndex((arg) => arg === name);
   if (exactIndex !== -1) {
     const next = process.argv[exactIndex + 1];
-    if (next && !next.startsWith("--")) return next;
+    if (next && !next.startsWith('--')) return next;
   }
 
   const prefix = `${name}=`;
   const arg = process.argv.find((entry) => entry.startsWith(prefix));
-  return arg ? arg.slice(prefix.length) : "";
+  return arg ? arg.slice(prefix.length) : '';
 }
 
 function parseInteger(value, fallback, { min = 0, max = 60_000 } = {}) {
-  const parsed = Number.parseInt(String(value ?? ""), 10);
+  const parsed = Number.parseInt(String(value ?? ''), 10);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(max, Math.max(min, parsed));
 }
@@ -31,7 +31,7 @@ function parseInteger(value, fallback, { min = 0, max = 60_000 } = {}) {
 function resolveBaseUrl() {
   return new URL(
     String(
-      getFlagValue("--url") ||
+      getFlagValue('--url') ||
         process.env.RAG_SYNC_BASE_URL ||
         process.env.SITE_URL ||
         DEFAULT_BASE_URL,
@@ -40,7 +40,7 @@ function resolveBaseUrl() {
 }
 
 function resolveFixturePath() {
-  const customPath = String(getFlagValue("--file") || "").trim();
+  const customPath = String(getFlagValue('--file') || '').trim();
   return customPath
     ? path.resolve(process.cwd(), customPath)
     : DEFAULT_FIXTURE_PATH;
@@ -49,12 +49,12 @@ function resolveFixturePath() {
 function getRetryConfig() {
   return {
     retries: parseInteger(
-      getFlagValue("--retries") || process.env.RAG_EVAL_RETRIES,
+      getFlagValue('--retries') || process.env.RAG_EVAL_RETRIES,
       DEFAULT_RETRIES,
       { min: 0, max: 20 },
     ),
     delayMs: parseInteger(
-      getFlagValue("--delay-ms") || process.env.RAG_EVAL_DELAY_MS,
+      getFlagValue('--delay-ms') || process.env.RAG_EVAL_DELAY_MS,
       DEFAULT_DELAY_MS,
       { min: 250, max: 60_000 },
     ),
@@ -66,17 +66,17 @@ function sleep(ms) {
 }
 
 async function loadCases(filePath) {
-  const raw = await readFile(filePath, "utf8");
+  const raw = await readFile(filePath, 'utf8');
   const parsed = JSON.parse(raw);
   if (!Array.isArray(parsed) || parsed.length === 0) {
-    throw new Error("Evaluation file must contain a non-empty JSON array");
+    throw new Error('Evaluation file must contain a non-empty JSON array');
   }
   return parsed;
 }
 
 async function fetchEvaluation(baseUrl, token, query) {
   const endpoint = new URL(ENDPOINT_PATH, baseUrl);
-  endpoint.searchParams.set("query", query);
+  endpoint.searchParams.set('query', query);
   const response = await fetch(endpoint, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -141,7 +141,7 @@ function assertCase(caseDefinition, retrieval) {
   const topMatch = matches[0] || null;
 
   if (!retrieval) {
-    errors.push("retrieval missing");
+    errors.push('retrieval missing');
     return { errors, sources, matches, topMatch };
   }
 
@@ -155,7 +155,7 @@ function assertCase(caseDefinition, retrieval) {
     !allowedRetrievalModes.includes(retrieval.retrievalMode)
   ) {
     errors.push(
-      `unexpected retrievalMode "${retrieval.retrievalMode}" (expected one of ${allowedRetrievalModes.join(", ")})`,
+      `unexpected retrievalMode "${retrieval.retrievalMode}" (expected one of ${allowedRetrievalModes.join(', ')})`,
     );
   }
 
@@ -178,7 +178,7 @@ function assertCase(caseDefinition, retrieval) {
     (!topMatch || !expectedSourceTypes.includes(topMatch.sourceType))
   ) {
     errors.push(
-      `top match sourceType "${topMatch?.sourceType || "missing"}" not in ${expectedSourceTypes.join(", ")}`,
+      `top match sourceType "${topMatch?.sourceType || 'missing'}" not in ${expectedSourceTypes.join(', ')}`,
     );
   }
 
@@ -189,12 +189,12 @@ function assertCase(caseDefinition, retrieval) {
     expectedUrlIncludes.length > 0 &&
     !sources.some((source) =>
       expectedUrlIncludes.some((needle) =>
-        String(source?.url || "").includes(needle),
+        String(source?.url || '').includes(needle),
       ),
     )
   ) {
     errors.push(
-      `no source URL matched ${expectedUrlIncludes.map((value) => `"${value}"`).join(", ")}`,
+      `no source URL matched ${expectedUrlIncludes.map((value) => `"${value}"`).join(', ')}`,
     );
   }
 
@@ -202,9 +202,9 @@ function assertCase(caseDefinition, retrieval) {
 }
 
 async function main() {
-  const token = String(process.env.ADMIN_TOKEN || "").trim();
+  const token = String(process.env.ADMIN_TOKEN || '').trim();
   if (!token) {
-    console.error("ADMIN_TOKEN fehlt.");
+    console.error('ADMIN_TOKEN fehlt.');
     process.exitCode = 1;
     return;
   }
@@ -216,13 +216,13 @@ async function main() {
 
   const results = [];
   for (const caseDefinition of cases) {
-    const query = String(caseDefinition?.query || "").trim();
+    const query = String(caseDefinition?.query || '').trim();
     const id = String(caseDefinition?.id || query).trim();
     if (!query) {
       results.push({
         id,
         ok: false,
-        errors: ["query missing"],
+        errors: ['query missing'],
       });
       continue;
     }
@@ -241,8 +241,8 @@ async function main() {
         query,
         attempt,
         endpoint: endpoint.toString(),
-        retrievalMode: payload?.retrieval?.retrievalMode || "",
-        topSourceType: evaluation.topMatch?.sourceType || "",
+        retrievalMode: payload?.retrieval?.retrievalMode || '',
+        topSourceType: evaluation.topMatch?.sourceType || '',
         sourceUrls: evaluation.sources.map((source) => source.url),
         errors: evaluation.errors,
       });
@@ -258,17 +258,17 @@ async function main() {
 
   const failures = results.filter((result) => !result.ok);
   for (const result of results) {
-    const prefix = result.ok ? "PASS" : "FAIL";
+    const prefix = result.ok ? 'PASS' : 'FAIL';
     const details = [
-      result.retrievalMode ? `mode=${result.retrievalMode}` : "",
-      result.topSourceType ? `top=${result.topSourceType}` : "",
+      result.retrievalMode ? `mode=${result.retrievalMode}` : '',
+      result.topSourceType ? `top=${result.topSourceType}` : '',
       Array.isArray(result.sourceUrls) && result.sourceUrls.length > 0
-        ? `sources=${result.sourceUrls.join(", ")}`
-        : "",
+        ? `sources=${result.sourceUrls.join(', ')}`
+        : '',
     ]
       .filter(Boolean)
-      .join(" | ");
-    console.log(`${prefix} ${result.id}${details ? ` | ${details}` : ""}`);
+      .join(' | ');
+    console.log(`${prefix} ${result.id}${details ? ` | ${details}` : ''}`);
     for (const error of result.errors || []) {
       console.log(`  - ${error}`);
     }

--- a/tests/content-rag.test.mjs
+++ b/tests/content-rag.test.mjs
@@ -1,24 +1,24 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
-import { buildSystemPrompt } from "../functions/api/_ai-prompts.js";
+import { buildSystemPrompt } from '../functions/api/_ai-prompts.js';
 import {
   buildSiteContentCorpus,
   getSiteContentRagContext,
   syncSiteContentRag,
-} from "../functions/api/_content-rag.js";
+} from '../functions/api/_content-rag.js';
 
 function jsonResponse(value) {
   return new Response(JSON.stringify(value), {
     status: 200,
-    headers: { "content-type": "application/json" },
+    headers: { 'content-type': 'application/json' },
   });
 }
 
 function textResponse(value) {
   return new Response(value, {
     status: 200,
-    headers: { "content-type": "text/plain; charset=utf-8" },
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
   });
 }
 
@@ -27,10 +27,10 @@ function buildAssets(files) {
     async fetch(url) {
       const path = new URL(url).pathname;
       if (!files.has(path)) {
-        return new Response("not found", { status: 404 });
+        return new Response('not found', { status: 404 });
       }
       const value = files.get(path);
-      return typeof value === "string"
+      return typeof value === 'string'
         ? textResponse(value)
         : jsonResponse(value);
     },
@@ -38,7 +38,7 @@ function buildAssets(files) {
 }
 
 function buildEmbedding(text) {
-  const normalized = String(text || "");
+  const normalized = String(text || '');
   let checksum = 0;
   for (const char of normalized) {
     checksum = (checksum + char.charCodeAt(0)) % 997;
@@ -47,23 +47,23 @@ function buildEmbedding(text) {
 }
 
 function createCorpusFiles({
-  blogBody = "Erste Version des Artikels.",
+  blogBody = 'Erste Version des Artikels.',
   includeAbout = false,
   includeProject = true,
 } = {}) {
   const files = new Map([
     [
-      "/pages/blog/posts/index.json",
+      '/pages/blog/posts/index.json',
       [
         {
-          id: "react-no-build",
-          file: "/pages/blog/posts/react-no-build.md",
-          title: "React No Build",
+          id: 'react-no-build',
+          file: '/pages/blog/posts/react-no-build.md',
+          title: 'React No Build',
         },
       ],
     ],
     [
-      "/pages/blog/posts/react-no-build.md",
+      '/pages/blog/posts/react-no-build.md',
       `---
 title: React No Build
 excerpt: Buildless React
@@ -79,19 +79,19 @@ ${blogBody}
 Web Components bleiben situativ spannend.`,
     ],
     [
-      "/pages/projekte/apps-config.json",
+      '/pages/projekte/apps-config.json',
       {
         apps: includeProject
           ? [
               {
-                name: "robot",
-                title: "Robot",
-                description: "Projektbeschreibung",
-                tags: ["ai", "ui"],
+                name: 'robot',
+                title: 'Robot',
+                description: 'Projektbeschreibung',
+                tags: ['ai', 'ui'],
                 caseStudy: {
-                  problem: "Fragen beantworten",
-                  solution: "RAG",
-                  results: "besser",
+                  problem: 'Fragen beantworten',
+                  solution: 'RAG',
+                  results: 'besser',
                 },
               },
             ]
@@ -102,7 +102,7 @@ Web Components bleiben situativ spannend.`,
 
   if (includeAbout) {
     files.set(
-      "/pages/about/index.html",
+      '/pages/about/index.html',
       `<!doctype html>
 <html lang="de">
   <head>
@@ -158,7 +158,7 @@ function createSyncEnv(files) {
         async get(key, type) {
           if (!manifestStore.has(key)) return null;
           const value = manifestStore.get(key);
-          return type === "json" ? JSON.parse(value) : value;
+          return type === 'json' ? JSON.parse(value) : value;
         },
         async put(key, value) {
           manifestStore.set(key, value);
@@ -180,10 +180,10 @@ async function withMockFetch(handler, callback) {
   }
 }
 
-test("content RAG prefers blog sources for opinion queries and exposes source links", async () => {
+test('content RAG prefers blog sources for opinion queries and exposes source links', async () => {
   const queryCalls = [];
   const result = await getSiteContentRagContext(
-    "Wie denkt Abdulkerim über Web Components?",
+    'Wie denkt Abdulkerim über Web Components?',
     {
       AI: {
         async run(_model, payload) {
@@ -193,26 +193,26 @@ test("content RAG prefers blog sources for opinion queries and exposes source li
       ROBOT_CONTENT_RAG: {
         async query(_vector, options) {
           queryCalls.push(options);
-          assert.deepEqual(options.filter, { sourceType: "blog" });
+          assert.deepEqual(options.filter, { sourceType: 'blog' });
 
           return {
             matches: [
               {
-                id: "rag-blog-1",
+                id: 'rag-blog-1',
                 score: 0.71,
                 metadata: {
-                  documentId: "blog-web-components-zukunft",
-                  sourceType: "blog",
-                  title: "Web Components Zukunft",
-                  url: "/blog/web-components-zukunft/",
-                  section: "Haltung",
+                  documentId: 'blog-web-components-zukunft',
+                  sourceType: 'blog',
+                  title: 'Web Components Zukunft',
+                  url: '/blog/web-components-zukunft/',
+                  section: 'Haltung',
                   content:
-                    "Ich nutze Web Components gezielt für langlebige Standards und bleibe sonst pragmatisch bei React.",
+                    'Ich nutze Web Components gezielt für langlebige Standards und bleibe sonst pragmatisch bei React.',
                   snippet:
-                    "Web Components für Standards, React für Produkt-Apps.",
-                  category: "frontend",
-                  tags: "web components, standards",
-                  date: "2026-03-10",
+                    'Web Components für Standards, React für Produkt-Apps.',
+                  category: 'frontend',
+                  tags: 'web components, standards',
+                  date: '2026-03-10',
                 },
               },
             ],
@@ -223,13 +223,13 @@ test("content RAG prefers blog sources for opinion queries and exposes source li
   );
 
   assert.equal(queryCalls.length, 1);
-  assert.equal(result.retrievalMode, "metadata-filter:blog");
+  assert.equal(result.retrievalMode, 'metadata-filter:blog');
   assert.deepEqual(result.sources, [
     {
-      title: "Web Components Zukunft",
-      url: "/blog/web-components-zukunft/",
-      sourceType: "blog",
-      date: "2026-03-10",
+      title: 'Web Components Zukunft',
+      url: '/blog/web-components-zukunft/',
+      sourceType: 'blog',
+      date: '2026-03-10',
     },
   ]);
   assert.match(
@@ -237,8 +237,8 @@ test("content RAG prefers blog sources for opinion queries and exposes source li
     /\[Web Components Zukunft\]\(\/blog\/web-components-zukunft\/\)/,
   );
 
-  const systemPrompt = buildSystemPrompt("", "", {
-    userRole: "guest",
+  const systemPrompt = buildSystemPrompt('', '', {
+    userRole: 'guest',
     availableTools: [],
     ragSources: result.sources,
   });
@@ -249,10 +249,10 @@ test("content RAG prefers blog sources for opinion queries and exposes source li
   );
 });
 
-test("content RAG falls back to unfiltered retrieval when metadata filtering is unavailable", async () => {
+test('content RAG falls back to unfiltered retrieval when metadata filtering is unavailable', async () => {
   const queryCalls = [];
   const result = await getSiteContentRagContext(
-    "Welches Projekt nutzt Web Components?",
+    'Welches Projekt nutzt Web Components?',
     {
       AI: {
         async run(_model, payload) {
@@ -262,27 +262,27 @@ test("content RAG falls back to unfiltered retrieval when metadata filtering is 
       ROBOT_CONTENT_RAG: {
         async query(_vector, options) {
           queryCalls.push(options);
-          if (options.filter?.sourceType === "project") {
-            throw new Error("metadata index missing");
+          if (options.filter?.sourceType === 'project') {
+            throw new Error('metadata index missing');
           }
 
           return {
             matches: [
               {
-                id: "rag-project-1",
+                id: 'rag-project-1',
                 score: 0.77,
                 metadata: {
-                  documentId: "project-design-system",
-                  sourceType: "project",
-                  title: "Design System",
-                  url: "/projekte/design-system/",
-                  section: "Projektüberblick",
+                  documentId: 'project-design-system',
+                  sourceType: 'project',
+                  title: 'Design System',
+                  url: '/projekte/design-system/',
+                  section: 'Projektüberblick',
                   content:
-                    "Komponentenbibliothek mit Web Components und React-Wrappern.",
-                  snippet: "Komponentenbibliothek mit Web Components.",
-                  category: "frontend",
-                  tags: "web components, react",
-                  date: "",
+                    'Komponentenbibliothek mit Web Components und React-Wrappern.',
+                  snippet: 'Komponentenbibliothek mit Web Components.',
+                  category: 'frontend',
+                  tags: 'web components, react',
+                  date: '',
                 },
               },
             ],
@@ -293,15 +293,15 @@ test("content RAG falls back to unfiltered retrieval when metadata filtering is 
   );
 
   assert.equal(queryCalls.length, 2);
-  assert.deepEqual(queryCalls[0].filter, { sourceType: "project" });
+  assert.deepEqual(queryCalls[0].filter, { sourceType: 'project' });
   assert.equal(queryCalls[1].filter, undefined);
-  assert.equal(result.retrievalMode, "fallback-unfiltered:project");
-  assert.equal(result.sources[0].url, "/projekte/design-system/");
+  assert.equal(result.retrievalMode, 'fallback-unfiltered:project');
+  assert.equal(result.sources[0].url, '/projekte/design-system/');
 });
 
-test("content RAG force reindex re-embeds unchanged documents", async () => {
+test('content RAG force reindex re-embeds unchanged documents', async () => {
   const state = createSyncEnv(createCorpusFiles());
-  const request = new Request("https://example.com/");
+  const request = new Request('https://example.com/');
 
   const first = await syncSiteContentRag({ env: state.env, request });
   const second = await syncSiteContentRag({ env: state.env, request });
@@ -318,9 +318,9 @@ test("content RAG force reindex re-embeds unchanged documents", async () => {
   assert.ok(forced.upsertedChunkCount > 0);
 });
 
-test("content RAG hybrid retrieval can return lexical about matches", async () => {
+test('content RAG hybrid retrieval can return lexical about matches', async () => {
   const result = await getSiteContentRagContext(
-    "Wer ist Abdulkerim in Berlin?",
+    'Wer ist Abdulkerim in Berlin?',
     {
       AI: {
         async run(_model, payload) {
@@ -334,31 +334,31 @@ test("content RAG hybrid retrieval can return lexical about matches", async () =
       },
       SITEMAP_CACHE_KV: {
         async get(key, type) {
-          if (key !== "robot-content-rag:search-index:v1" || type !== "json") {
+          if (key !== 'robot-content-rag:search-index:v1' || type !== 'json') {
             return null;
           }
 
           return {
             version: 3,
-            syncedAt: "2026-03-11T00:00:00.000Z",
+            syncedAt: '2026-03-11T00:00:00.000Z',
             recordCount: 1,
             records: [
               {
-                id: "rag-about-1",
-                documentId: "about-profile",
-                sourceType: "about",
-                title: "Über Abdulkerim Sesli",
-                url: "/about/",
-                section: "Einleitung",
+                id: 'rag-about-1',
+                documentId: 'about-profile',
+                sourceType: 'about',
+                title: 'Über Abdulkerim Sesli',
+                url: '/about/',
+                section: 'Einleitung',
                 snippet:
-                  "Entwickler aus Berlin mit Fokus auf Webanwendungen und Zusammenarbeit.",
+                  'Entwickler aus Berlin mit Fokus auf Webanwendungen und Zusammenarbeit.',
                 content:
-                  "Abdulkerim Sesli ist Entwickler aus Berlin und baut performante Webanwendungen.",
-                category: "profil",
-                tagsText: "about, profil, berlin, services",
-                date: "2025-12-31T12:00:00Z",
+                  'Abdulkerim Sesli ist Entwickler aus Berlin und baut performante Webanwendungen.',
+                category: 'profil',
+                tagsText: 'about, profil, berlin, services',
+                date: '2025-12-31T12:00:00Z',
                 searchText:
-                  "about Über Abdulkerim Sesli Einleitung profil about profil berlin services Entwickler aus Berlin Webanwendungen Zusammenarbeit",
+                  'about Über Abdulkerim Sesli Einleitung profil about profil berlin services Entwickler aus Berlin Webanwendungen Zusammenarbeit',
               },
             ],
           };
@@ -368,30 +368,30 @@ test("content RAG hybrid retrieval can return lexical about matches", async () =
   );
 
   assert.ok(result);
-  assert.equal(result.retrievalMode, "fallback-unfiltered:about");
+  assert.equal(result.retrievalMode, 'fallback-unfiltered:about');
   assert.equal(result.hybridSignals.vectorMatchCount, 0);
   assert.equal(result.hybridSignals.lexicalMatchCount, 1);
   assert.equal(result.hybridSignals.usedLexicalMatch, true);
-  assert.equal(result.sources[0].url, "/about/");
-  assert.equal(result.matches[0].sourceType, "about");
+  assert.equal(result.sources[0].url, '/about/');
+  assert.equal(result.matches[0].sourceType, 'about');
 });
 
-test("content RAG corpus includes about and video sources when available", async () => {
+test('content RAG corpus includes about and video sources when available', async () => {
   const state = createSyncEnv(createCorpusFiles({ includeAbout: true }));
-  state.env.YOUTUBE_CHANNEL_ID = "UCTESTCHANNEL";
-  state.env.YOUTUBE_API_KEY = "test-key";
+  state.env.YOUTUBE_CHANNEL_ID = 'UCTESTCHANNEL';
+  state.env.YOUTUBE_API_KEY = 'test-key';
 
   await withMockFetch(
     async (input) => {
-      const url = new URL(typeof input === "string" ? input : input.url);
+      const url = new URL(typeof input === 'string' ? input : input.url);
 
-      if (url.pathname === "/youtube/v3/channels") {
+      if (url.pathname === '/youtube/v3/channels') {
         return jsonResponse({
           items: [
             {
               contentDetails: {
                 relatedPlaylists: {
-                  uploads: "UPLOADS123",
+                  uploads: 'UPLOADS123',
                 },
               },
             },
@@ -399,16 +399,16 @@ test("content RAG corpus includes about and video sources when available", async
         });
       }
 
-      if (url.pathname === "/youtube/v3/playlistItems") {
+      if (url.pathname === '/youtube/v3/playlistItems') {
         return jsonResponse({
           items: [
             {
               snippet: {
-                resourceId: { videoId: "abc123xyz89" },
-                title: "Neon Robot Motion Design",
-                description: "Motion Design Video über Neon Bot Animation.",
-                channelTitle: "Abdulkerim Sesli",
-                publishedAt: "2026-03-01T10:00:00Z",
+                resourceId: { videoId: 'abc123xyz89' },
+                title: 'Neon Robot Motion Design',
+                description: 'Motion Design Video über Neon Bot Animation.',
+                channelTitle: 'Abdulkerim Sesli',
+                publishedAt: '2026-03-01T10:00:00Z',
               },
             },
           ],
@@ -420,7 +420,7 @@ test("content RAG corpus includes about and video sources when available", async
     async () => {
       const corpus = await buildSiteContentCorpus({
         env: state.env,
-        request: new Request("https://example.com/"),
+        request: new Request('https://example.com/'),
       });
 
       assert.equal(corpus.sourceBreakdown.documents.about, 1);
@@ -428,14 +428,14 @@ test("content RAG corpus includes about and video sources when available", async
       assert.ok(
         corpus.documents.some(
           (document) =>
-            document.sourceType === "about" && document.url === "/about/",
+            document.sourceType === 'about' && document.url === '/about/',
         ),
       );
       assert.ok(
         corpus.documents.some(
           (document) =>
-            document.sourceType === "video" &&
-            document.url === "/videos/abc123xyz89/",
+            document.sourceType === 'video' &&
+            document.url === '/videos/abc123xyz89/',
         ),
       );
     },


### PR DESCRIPTION
This pull request addresses the performance issue ("Chat Antwort dauert lange") in the AI Agent.

### Changes
*   **Timeouts for RAG & Memory**: A new `withTimeout` utility binds `resolveMemoryContext`, `getRAGContext`, and `persistPromptMemories` to a strict `3500ms` window. If Vectorize, KV, or the underlying `@cf/baai/bge-base-en-v1.5` embeddings take too long, the system gracefully bypasses them to ensure the user receives a chat response quickly without hanging.
*   **Parallel Memory Persistence**: The `persistPromptMemories` function was refactored. Instead of a sequential `for...of` loop awaiting each `storeMemory` call, it now builds an array of promises and utilizes `Promise.allSettled`. This drops the "N+1 query" overhead where storing 3 facts previously took 3x longer than storing 1 fact.
*   (Some files display format adjustments due to Prettier normalizing `""` strings to `''` via `npm run format` / `qa`).

All unit tests and quality checks (`npm run qa`) pass.

---
*PR created automatically by Jules for task [1075016003734008135](https://jules.google.com/task/1075016003734008135) started by @aKs030*